### PR TITLE
[Feature] 구독 완료 후 피드백 UI 추가 및 구독 상태 변경 로직 개선

### DIFF
--- a/src/app/(home)/_components/SubscribeSection.tsx
+++ b/src/app/(home)/_components/SubscribeSection.tsx
@@ -12,18 +12,39 @@ import CardSlider from '@/components/common/slider/CardSlider';
 import { BiCheck, BiPlus } from 'react-icons/bi';
 import useSelectInterests from '@/hooks/useSelectInterests';
 
+import ModalContents from '@/components/common/modal/ModalContent';
+import { LuMailCheck } from 'react-icons/lu';
+import { useModal } from '@/hooks/useModal';
+import { useToast } from '@/hooks/useToast';
+
 const SubscribeSection = () => {
-	const { selectedInterests, handleSelectInterests } = useSelectInterests();
 	const {
 		status: isSubscribed,
 		isChanging: isChangingSubscription,
 		handleSubscribe: startSubscription,
 	} = useSubscribe();
+	const { selectedInterests, handleSelectInterests } = useSelectInterests();
 	const { isChecked } = useInputCheck('home-agreement');
+	const { openModal, closeModal } = useModal();
+	const { showToast } = useToast();
 
 	const handleSubscribe = (e: React.FormEvent) => {
 		e.preventDefault();
-		startSubscription({ interests: selectedInterests, isChecked: isChecked });
+		const isSuccess = startSubscription({ interests: selectedInterests, isChecked: isChecked });
+
+		if (isSuccess) {
+			openModal(
+				<ModalContents
+					icon={<LuMailCheck />}
+					title="구독 설정이 완료되었습니다"
+					content={`내일부터 새로운 뉴스레터를 보내드려요.`}
+					filledButton="확인"
+					onConfirmClick={closeModal}
+				/>
+			);
+		} else {
+			showToast('구독에 실패했습니다. 다시 시도해주세요.', 'error');
+		}
 	};
 
 	return (

--- a/src/app/(protected)/mypage/_components/settings/StartSubscription.tsx
+++ b/src/app/(protected)/mypage/_components/settings/StartSubscription.tsx
@@ -41,6 +41,7 @@ const StartSubscription = () => {
 				/>
 			);
 			setChecked(false);
+			handleSelectInterests();
 		}
 	};
 

--- a/src/hooks/useSelectInterests.ts
+++ b/src/hooks/useSelectInterests.ts
@@ -7,17 +7,12 @@ const useSelectInterests = () => {
 	const { user } = useAuth();
 	const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
 
-	// 사용자 관심사 반영 (초기 로드 및 관심사 업데이트 시)
-	useEffect(() => {
-		if (user?.interests?.length) {
-			setSelectedInterests(user.interests);
-		} else {
-			setSelectedInterests([]);
-		}
-	}, [user?.interests]);
-
 	// 카테고리 선택 / 해제
-	const handleSelectInterests = (category: Category) => {
+	const handleSelectInterests = (category?: Category) => {
+		if (!category) {
+			return setSelectedInterests([]);
+		}
+
 		if (category.title === '전체') {
 			if (selectedInterests.includes('전체')) {
 				setSelectedInterests([]);
@@ -39,10 +34,12 @@ const useSelectInterests = () => {
 		}
 	};
 
-	// 사용자 관심사 반영 (초기 로드 시)
+	// 사용자 관심사 반영 (초기 로드 및 관심사 업데이트 시)
 	useEffect(() => {
 		if (user?.interests?.length) {
 			setSelectedInterests(user.interests);
+		} else {
+			setSelectedInterests([]);
 		}
 	}, [user?.interests]);
 

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -45,6 +45,7 @@ export const useSubscribeStatus = () => {
 	}, [subscriptionStatus, user, setUser]);
 
 	const refreshSubscription = async () => {
+		await queryClient.invalidateQueries({ queryKey: ['user'] });
 		await queryClient.invalidateQueries({ queryKey: ['subscriptionStatus'] });
 		return await refetchStatus();
 	};


### PR DESCRIPTION
## 작업 개요

리팩토링 과정에서 누락된 UI를 재반영했습니다.
홈 화면의 빠른 구독 섹션에서 구독 완료 후 피드백 UI를 추가하고, 구독 상태 변경 시 `user` 정보가 갱신되도록 수정하였습니다.

## 관련 이슈

- #30 

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 개선

## 주요 변경 사항

- 구독 완료 후 사용자에게 피드백을 제공하는 UI 추가
- 구독 상태 변경 시 `user` 정보를 자동으로 `refetch`하도록 수정
- 구독 해제 시 체크박스 상태를 초기화하여 UI 일관성 유지

## 테스트 결과

- [x] 구독 완료 후 피드백 UI 정상 출력 확인
- [x] 구독 상태 변경 시 `user` 정보가 즉시 반영되는지 확인
- [x] 구독 해제 시 체크박스 상태가 초기화되는지 테스트