### PR TITLE
[Fix] 새로고침 할 때 빈 유저가 생기는 문제 해결

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -69,6 +69,11 @@ export const fetchUser = async (): Promise<User> => {
 		if (!response.ok) console.log(`사용자 정보를 불러오는데 실패했습니다. ${response.status}`);
 
 		const user = await fetchAdditionalUserData(await response.json());
+
+		if (!user) {
+			throw new Error('사용자 정보를 불러오는데 실패했습니다.');
+		}
+
 		return user;
 	} catch (error) {
 		console.log('❌ 사용자 정보 조회 실패:', error);
@@ -143,10 +148,12 @@ export const fetchWithAuth = async (url: string, options: RequestInit = {}): Pro
 					console.log('❌ 재발급된 토큰으로도 인증 실패. 로그아웃합니다.');
 					alert('세션이 만료되었습니다. 다시 로그인해주세요.');
 					await logoutUser();
+					throw new Error('세션이 만료되었습니다. 다시 로그인해주세요.');
 				}
 			} catch (refreshError) {
 				console.log('❌ 토큰 재발급 실패:', refreshError);
 				await logoutUser();
+				throw new Error('세션이 만료되었습니다. 다시 로그인해주세요.');
 			}
 		}
 


### PR DESCRIPTION
### 작업 개요
- 로그아웃 상태에서 새로고침할 때 유저 상태가 올바르게 초기화되지 않아 빈 유저 데이터(에러 메시지가 유저에 삽입되면서 유저가 존재하는 것처럼 표시됨)가 들어가는 문제를 해결했습니다.

### PR 유형
- [x] 버그 수정

### 변경 이유
- 로그아웃 후 새로고침 시 빈 유저 데이터가 들어가는 버그를 해결하기 위함.

### 테스트 결과
- 로그아웃 후 새로고침 시 로그인 버튼이 정상적으로 표시됨.
- 로그인 상태에서 새로고침해도 유지됨.