### PR TITLE
[Feature] 홈화면에 뉴스레터 데이터 연동

### DIFF
--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -21,7 +21,22 @@ export const fetchArticle = async (slug: string) => {
 	if (!response.ok) {
 		throw new Error('아티클을 불러오는데 실패했습니다.');
 	}
-	const data = await response.json();
+	const article = await response.json();
 
-	return data.data;
+	return article.data;
+};
+
+export const fetchTrendList = async (category?: number) => {
+	try {
+		const response = await fetch(API_ENDPOINTS.NEWSLETTER.TRENDS(category));
+
+		if (!response.ok) {
+			throw new Error('트렌드 리스트를 불러오는데 실패했습니다.');
+		}
+
+		const trends = await response.json();
+		return trends.data;
+	} catch (error) {
+		console.error(error);
+	}
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -147,12 +147,12 @@ export const fetchWithAuth = async (url: string, options: RequestInit = {}): Pro
 				if (response.status === 401) {
 					console.log('❌ 재발급된 토큰으로도 인증 실패. 로그아웃합니다.');
 					await logoutUser();
-					throw new Error('세션이 만료되었습니다. 다시 로그인해주세요.');
+					throw new Error('로그인 후 이용해주세요.');
 				}
 			} catch (refreshError) {
 				console.log('❌ 토큰 재발급 실패:', refreshError);
 				await logoutUser();
-				throw new Error('세션이 만료되었습니다. 다시 로그인해주세요.');
+				throw new Error('로그인 후 이용해주세요.');
 			}
 		}
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -146,7 +146,6 @@ export const fetchWithAuth = async (url: string, options: RequestInit = {}): Pro
 				// 여전히 401이면 로그아웃 처리
 				if (response.status === 401) {
 					console.log('❌ 재발급된 토큰으로도 인증 실패. 로그아웃합니다.');
-					alert('세션이 만료되었습니다. 다시 로그인해주세요.');
 					await logoutUser();
 					throw new Error('세션이 만료되었습니다. 다시 로그인해주세요.');
 				}

--- a/src/app/(home)/_components/SubscribeSection.tsx
+++ b/src/app/(home)/_components/SubscribeSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { ArticleCard as IArticleCard } from '@/models/article.model';
 import { CATEGORIES } from '@/constants/categories';
 import { useInputCheck } from '@/hooks/useInputCheck';
 import { useSubscribe } from '@/hooks/useSubscribe';
@@ -18,7 +19,11 @@ import ModalContents from '@/components/common/modal/ModalContent';
 import { LuMailCheck } from 'react-icons/lu';
 import { useModal } from '@/hooks/useModal';
 
-const SubscribeSection = () => {
+interface Props {
+	trends: IArticleCard[];
+}
+
+const SubscribeSection = ({ trends }: Props) => {
 	const {
 		status: isSubscribed,
 		isChanging: isChangingSubscription,
@@ -45,34 +50,45 @@ const SubscribeSection = () => {
 		}
 	};
 
+	if (!trends) return null;
+
 	return (
 		<StyledSubscribe>
 			<CardSlider
 				className="quick-subscription"
 				type="sub"
-				data={CATEGORIES.map((category) => ({
-					id: category.id ?? 0,
-					image: `https://picsum.photos/400/300?random=${category.id}`,
-					header: category.name,
-					main: {
-						title: undefined,
-						description: `${category.name} 분야의 최신 뉴스레터를 구독하세요.`,
-					},
-					footer: (
-						<Button
-							key={category.id}
-							scheme={selectedInterests.includes(category.name) ? 'primary' : 'outline'}
-							onClick={() => handleSelectInterests(category)}
-							icon={selectedInterests.includes(category.name) ? <BiCheck /> : <BiPlus />}
-							style={{
-								width: '100%',
-							}}
-							disabled={isChangingSubscription}
-						>
-							{selectedInterests.includes(category.name) ? <>Selected</> : <>Select</>}
-						</Button>
-					),
-				}))}
+				data={CATEGORIES.map((category) => {
+					// 카테고리 이름이 '전체'인 경우 기본 이미지를 사용.
+					const image =
+						category.name === '전체'
+							? '/img/newpick_default_img.jpg'
+							: trends.find((trend) => trend.categoryName === category.name)?.image ||
+							  '/img/newpick_default_img.jpg';
+
+					return {
+						id: category.id ?? 0,
+						image,
+						header: category.name,
+						main: {
+							title: undefined,
+							description: `${category.name} 분야의 최신 뉴스레터를 구독하세요.`,
+						},
+						footer: (
+							<Button
+								key={category.id}
+								scheme={selectedInterests.includes(category.name) ? 'primary' : 'outline'}
+								onClick={() => handleSelectInterests(category)}
+								icon={selectedInterests.includes(category.name) ? <BiCheck /> : <BiPlus />}
+								style={{
+									width: '100%',
+								}}
+								disabled={isChangingSubscription}
+							>
+								{selectedInterests.includes(category.name) ? <>Selected</> : <>Select</>}
+							</Button>
+						),
+					};
+				})}
 			/>
 
 			<div className="subscription-form">

--- a/src/app/(home)/_components/TrendSection.tsx
+++ b/src/app/(home)/_components/TrendSection.tsx
@@ -1,22 +1,21 @@
 'use client';
 
 import { Suspense, lazy } from 'react';
-import { useNewsletter } from '@/hooks/useNewsletter';
-import { filterTodayTrends } from '@/utils/queryNewsletters';
+import { ArticleCard as IArticleCard } from '@/models/article.model';
 
 import { styled } from 'styled-components';
-import { IoIosHeartEmpty } from 'react-icons/io';
 import Title from '@/components/common/Title';
 import Text from '@/components/common/Text';
-import Button from '@/components/common/Button';
 import Skeleton from '@/components/common/loader/Skeleton';
-
+import BookmarkIcon from '@/components/common/icons/BookmarkIcon';
 const LazyCard = lazy(() => import('@/components/common/Card'));
 
-const TrendSection = () => {
-	const { newsletters } = useNewsletter();
-	const todayTrends = filterTodayTrends(newsletters);
-	const isLoading = newsletters.length === 0;
+interface Props {
+	trends: IArticleCard[];
+}
+
+const TrendSection = ({ trends = [] }: Props) => {
+	const isLoading = trends.length === 0;
 
 	return (
 		<StyledTrendSection>
@@ -32,13 +31,14 @@ const TrendSection = () => {
 			) : (
 				<Suspense fallback={<Skeleton />}>
 					<div className="trend-cards">
-						{todayTrends.map((trend) => (
+						{trends.map((trend) => (
 							<LazyCard
 								key={trend.id}
 								data={{
 									id: trend.id,
+									url: `/articles/detail/${trend.id}`,
 									image: trend.image,
-									header: trend.category,
+									header: trend.categoryName,
 									main: {
 										title: trend.title,
 										description: trend.summary,
@@ -47,9 +47,7 @@ const TrendSection = () => {
 										<>
 											<Text color="subText">{trend.date}</Text>
 											<div className="right">
-												<Button className="rounded-icon-button">
-													<IoIosHeartEmpty />
-												</Button>
+												<BookmarkIcon newsId={trend.id} newsletterId={trend.id} />
 											</div>
 										</>
 									),

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,16 +1,40 @@
+import { ArticleDetail as IArticleDetail, ArticleCard as IArticleCard } from '@/models/article.model';
+import { fetchTrendList } from '@/api/article';
+import { getFirstImage } from '@/utils/getFirstImage';
+import { mapIdToTitle } from '@/utils/mapInterests';
+import { stripCodeFence } from '@/utils/stripCodeFence';
+import { dateFormatter } from '@/utils/formatter';
+
+import styles from '@/app/(home)/home.module.css';
 import Title from '@/components/common/Title';
 import FullWidthPanel from '@/components/common/FullWidthPanel';
 import HeroSection from '@/app/(home)/_components/HeroSection';
 import TrendSection from '@/app/(home)/_components/TrendSection';
 import SubscribeSection from '@/app/(home)/_components/SubscribeSection';
-import styles from '@/app/(home)/home.module.css';
 
 export default async function HomePage() {
+	let parsedTrends: IArticleCard[] = [];
+	try {
+		const trends: IArticleDetail[] = await fetchTrendList();
+		parsedTrends = trends.map((trend) => ({
+			id: trend.id,
+			categoryName: mapIdToTitle([trend.categoryId])[0],
+			image: getFirstImage(trend.imageUrl!) || '',
+			title: stripCodeFence(trend.title),
+			summary: stripCodeFence(trend.content),
+			date: dateFormatter(trend.createdAt),
+		}));
+
+		console.log(parsedTrends);
+	} catch (error) {
+		console.error(error);
+	}
+
 	return (
 		<div className={styles.homePage}>
 			<HeroSection />
 			<hr />
-			<TrendSection />
+			<TrendSection trends={parsedTrends} />
 
 			<FullWidthPanel>
 				<Title size="extraLarge" weight="bold" color="background">
@@ -18,7 +42,7 @@ export default async function HomePage() {
 				</Title>
 			</FullWidthPanel>
 
-			<SubscribeSection />
+			<SubscribeSection trends={parsedTrends} />
 		</div>
 	);
 }

--- a/src/app/(protected)/mypage/page.tsx
+++ b/src/app/(protected)/mypage/page.tsx
@@ -6,7 +6,6 @@ import TabNavigation from '@/components/common/TabNavgation';
 import MyTabs from '@/app/(protected)/mypage/_components/MyTabs';
 
 export default async function MyPage() {
-
 	return (
 		<div className={styles.myPage}>
 			<Title size="extraSmall">마이페이지</Title>

--- a/src/app/articles/detail/[slug]/_components/Article.tsx
+++ b/src/app/articles/detail/[slug]/_components/Article.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import styled from 'styled-components';
 import SummaryTextBox from '@/components/common/article/SummaryTextBox';
@@ -7,7 +7,7 @@ import ArticleContent from '@/app/articles/detail/[slug]/_components/content/Art
 import PrevNextArticle from '@/app/articles/detail/[slug]/_components/PrevNextArticle';
 import LatestArticle from '@/app/articles/detail/[slug]/_components/LatestArticle';
 import MobileLikeLinkButton from '@/app/articles/detail/[slug]/_components/MobileLikeLinkButton';
-import { IArticleDetail } from '@/models/article.model';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import MoveButton from '@/components/common/MoveButton';
 import { IoArrowBack } from 'react-icons/io5';
 import Link from 'next/link';
@@ -18,152 +18,152 @@ import { useCategoryStore } from '@/stores/useCategoryStore';
 import { useEffect } from 'react';
 
 interface Props {
-  article: IArticleDetail;
-  summary: string;
-  content: string;
-  popular: IArticleDetail[];
-  latest: IArticleDetail[];
-  newsId: number;
-  prev: IArticleDetail | null;
-  next: IArticleDetail | null;
+	article: IArticleDetail;
+	summary: string;
+	content: string;
+	popular: IArticleDetail[];
+	latest: IArticleDetail[];
+	newsId: number;
+	prev: IArticleDetail | null;
+	next: IArticleDetail | null;
 }
 
 function Article({ article, summary, content, popular, latest, newsId, prev, next }: Props) {
-  const router = useRouter();
-  const { categories, fetchCategories, getCategoryName } = useCategoryStore();
+	const router = useRouter();
+	const { categories, fetchCategories, getCategoryName } = useCategoryStore();
 
-  useEffect(() => {
-    if (Object.keys(categories).length === 0) {
-      fetchCategories();
-    }
-  }, [categories, fetchCategories]);
-  return (
-    <>
-      <TitleSectionStyled>
-        <MoveButton onClick={() => router.back()} text="이전으로" frontIcon={<IoArrowBack />} />
-        <div className="title-section">
-          <Link href={`/articles/categories/${article.categoryId}`} className="category">{getCategoryName(article.categoryId)}</Link>
-          <h1 className="title">{article.title}</h1>
-          <p className="date">{article.createdAt}</p>
-          <div className="icons">
-            <BookmarkIcon newsId={article.id} newsletterId={article.id} />
-            <LinkCopyIcon id={article.id} />
-          </div>
-        </div>
-      </TitleSectionStyled>
-      <ArticleStyled>
-        <SummaryTextBox>{summary}</SummaryTextBox>
-        <div className="content-section">
-          <ArticleContent className="content" content={content} articleImage={article.imageUrl ?? ""} />
-          <PopularArticle className="popular" popular={popular} />
-        </div>
-        <PrevNextArticle className="prev-next" prev={prev} next={next} />
-        {/*<CommentsSection className="comments-section"/>*/}
-        <LatestArticle className="latest" latest={latest} />
-        <MobileLikeLinkButton className="icons" newsId={newsId} />
-      </ArticleStyled>
-    </>
-  );
+	useEffect(() => {
+		if (Object.keys(categories).length === 0) {
+			fetchCategories();
+		}
+	}, [categories, fetchCategories]);
+	return (
+		<>
+			<TitleSectionStyled>
+				<MoveButton onClick={() => router.back()} text="이전으로" frontIcon={<IoArrowBack />} />
+				<div className="title-section">
+					<Link href={`/articles/categories/${article.categoryId}`} className="category">
+						{getCategoryName(article.categoryId)}
+					</Link>
+					<h1 className="title">{article.title}</h1>
+					<p className="date">{article.createdAt}</p>
+					<div className="icons">
+						<BookmarkIcon newsId={article.id} newsletterId={article.id} />
+						<LinkCopyIcon id={article.id} />
+					</div>
+				</div>
+			</TitleSectionStyled>
+			<ArticleStyled>
+				<SummaryTextBox>{summary}</SummaryTextBox>
+				<div className="content-section">
+					<ArticleContent className="content" content={content} articleImage={article.imageUrl ?? ''} />
+					<PopularArticle className="popular" popular={popular} />
+				</div>
+				<PrevNextArticle className="prev-next" prev={prev} next={next} />
+				{/*<CommentsSection className="comments-section"/>*/}
+				<LatestArticle className="latest" latest={latest} />
+				<MobileLikeLinkButton className="icons" newsId={newsId} />
+			</ArticleStyled>
+		</>
+	);
 }
 
 const ArticleStyled = styled.div`
-    margin: 4rem 0;
-    position: relative;
-    width: 100%;
-    height: auto;
+	margin: 4rem 0;
+	position: relative;
+	width: 100%;
+	height: auto;
 
-    .content-section {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-start;
-        gap: 2rem;
-        margin: 2rem 0;
+	.content-section {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+		gap: 2rem;
+		margin: 2rem 0;
 
-        .content {
-            flex: 3;
-        }
+		.content {
+			flex: 3;
+		}
 
-        .popular {
-            flex: 1;
-            margin-top: 2rem;
-        }
-    }
+		.popular {
+			flex: 1;
+			margin-top: 2rem;
+		}
+	}
 
-    .comments-section {
-        margin: 4rem 0;
-    }
+	.comments-section {
+		margin: 4rem 0;
+	}
 
-    @media screen and ${({ theme }) => theme.mediaQuery.tablet} {
-        display: flex;
-        flex-direction: column;
+	@media screen and ${({ theme }) => theme.mediaQuery.tablet} {
+		display: flex;
+		flex-direction: column;
 
-        .content-section {
-            flex-direction: column;
+		.content-section {
+			flex-direction: column;
 
-            .content {
-                border-bottom: 1px solid ${({ theme }) => theme.color.border};
-                margin-bottom: 2rem;
-            }
+			.content {
+				border-bottom: 1px solid ${({ theme }) => theme.color.border};
+				margin-bottom: 2rem;
+			}
 
-            .popular {
-                order: 4;
-            }
-        }
-    }
+			.popular {
+				order: 4;
+			}
+		}
+	}
 
-    .induce {
-        order: 1;
-    }
+	.induce {
+		order: 1;
+	}
 
-    .prev-next {
-        order: 2;
-    }
+	.prev-next {
+		order: 2;
+	}
 
-    .latest {
-        order: 3;
-    }
+	.latest {
+		order: 3;
+	}
 `;
 
-
 const TitleSectionStyled = styled.div`
-    margin-top: 4rem;
-    display: flex;
-    flex-direction: column;
-    border-bottom: 1px solid ${({ theme }) => theme.color.border};
+	margin-top: 4rem;
+	display: flex;
+	flex-direction: column;
+	border-bottom: 1px solid ${({ theme }) => theme.color.border};
 
-    .title-section {
-        text-align: center;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        gap: 0.25rem;
-        margin: 1.25rem 0;
+	.title-section {
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		gap: 0.25rem;
+		margin: 1.25rem 0;
 
-        .category {
-            color: ${({ theme }) => theme.color.primary};
-            font-weight: ${({ theme }) => theme.fontWeight.medium};
-        }
+		.category {
+			color: ${({ theme }) => theme.color.primary};
+			font-weight: ${({ theme }) => theme.fontWeight.medium};
+		}
 
-        .title {
-            word-break: auto-phrase;
-        }
+		.title {
+			word-break: auto-phrase;
+		}
 
-        .icons {
-            display: flex;
-            flex-direction: row;
-            gap: 1rem;
-            justify-content: center;
-            align-items: center;
-            margin-top: 0.75rem;
-        }
+		.icons {
+			display: flex;
+			flex-direction: row;
+			gap: 1rem;
+			justify-content: center;
+			align-items: center;
+			margin-top: 0.75rem;
+		}
 
-        .date {
-            color: ${({ theme }) => theme.color.lightGrey};
-            font-size: ${({ theme }) => theme.fontSize.extraSmall};
-        }
-    }
-
+		.date {
+			color: ${({ theme }) => theme.color.lightGrey};
+			font-size: ${({ theme }) => theme.fontSize.extraSmall};
+		}
+	}
 `;
 
 export default Article;

--- a/src/app/articles/detail/[slug]/_components/LatestArticle.tsx
+++ b/src/app/articles/detail/[slug]/_components/LatestArticle.tsx
@@ -8,7 +8,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import { Navigation } from 'swiper/modules';
-import { IArticleDetail } from '@/models/article.model';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 
 interface Props {
 	latest: IArticleDetail[];

--- a/src/app/articles/detail/[slug]/_components/PopularArticle.tsx
+++ b/src/app/articles/detail/[slug]/_components/PopularArticle.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Link from 'next/link';
 import HeightAutoImg from '@/components/common/HeightAutoImg';
-import { IArticleDetail } from '@/models/article.model';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import { dateFormatter } from '@/utils/formatter';
 import { getFirstImage } from '@/utils/getFirstImage';
 
@@ -12,7 +12,6 @@ interface Props {
 }
 
 function PopularArticle({ popular, flex, className }: Props) {
-
 	return (
 		<PopularNewsletterStyled flex={flex} className={className}>
 			<h3 className="section-title">지금 인기 아티클 TOP 5</h3>

--- a/src/app/articles/detail/[slug]/_components/PrevNextArticle.tsx
+++ b/src/app/articles/detail/[slug]/_components/PrevNextArticle.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { useState } from 'react';
 import styled from 'styled-components';
@@ -6,7 +6,7 @@ import MoveButton from '@/components/common/MoveButton';
 import { IoArrowBack, IoArrowForward } from 'react-icons/io5';
 import HeightAutoImg from '@/components/common/HeightAutoImg';
 import Link from 'next/link';
-import { IArticleDetail } from '@/models/article.model';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import { dateFormatter } from '@/utils/formatter';
 
 interface Props {
@@ -83,87 +83,87 @@ function PrevNextArticle({ className, prev, next }: Props) {
 	return (
 		<PrevNextArticleStyled className={className}>
 			<ul>
-				{renderArticle(prev, 'prev')}  {/* 이전글 */}
-				{renderArticle(next, 'next')}  {/* 다음글 */}
+				{renderArticle(prev, 'prev')} {/* 이전글 */}
+				{renderArticle(next, 'next')} {/* 다음글 */}
 			</ul>
 		</PrevNextArticleStyled>
 	);
 }
 
 const PrevNextArticleStyled = styled.section`
-  border-top: 1px solid ${({ theme }) => theme.color.border};
+	border-top: 1px solid ${({ theme }) => theme.color.border};
 
-  ul {
-    li.prev-next {
-      display: flex;
-      flex-direction: row;
-      gap: 1.5rem;
-      align-items: center;
-      height: fit-content;
-      border-bottom: 1px solid ${({ theme }) => theme.color.border};
-      padding: 2.5rem 1rem;
+	ul {
+		li.prev-next {
+			display: flex;
+			flex-direction: row;
+			gap: 1.5rem;
+			align-items: center;
+			height: fit-content;
+			border-bottom: 1px solid ${({ theme }) => theme.color.border};
+			padding: 2.5rem 1rem;
 
-      .link {
-        display: contents;
+			.link {
+				display: contents;
 
-        .btn {
-          flex: 0.8;
-        }
+				.btn {
+					flex: 0.8;
+				}
 
-        .img {
-          flex: 1.2;
-          margin: 0;
-        }
+				.img {
+					flex: 1.2;
+					margin: 0;
+				}
 
-        .text-section {
-          flex: 8;
+				.text-section {
+					flex: 8;
 
-          .title {
-            color: ${({ theme }) => theme.color.mediumGrey};
-            font-size: ${({ theme }) => theme.fontSize.medium};
-            font-weight: ${({ theme }) => theme.fontWeight.medium};
-            margin-bottom: 0.5rem;
+					.title {
+						color: ${({ theme }) => theme.color.mediumGrey};
+						font-size: ${({ theme }) => theme.fontSize.medium};
+						font-weight: ${({ theme }) => theme.fontWeight.medium};
+						margin-bottom: 0.5rem;
 
-            overflow: hidden;
-            text-overflow: ellipsis;
-            display: -webkit-box;
-            -webkit-line-clamp: 1;
-            -webkit-box-orient: vertical;
-          }
+						overflow: hidden;
+						text-overflow: ellipsis;
+						display: -webkit-box;
+						-webkit-line-clamp: 1;
+						-webkit-box-orient: vertical;
+					}
 
-          .date {
-            color: ${({ theme }) => theme.color.lightGrey};
-            font-size: ${({ theme }) => theme.fontSize.extraSmall};
-          }
-        }
-      }
+					.date {
+						color: ${({ theme }) => theme.color.lightGrey};
+						font-size: ${({ theme }) => theme.fontSize.extraSmall};
+					}
+				}
+			}
 
-      &.active {
-        background-color: ${({ theme }) => theme.color.surface};
-      }
+			&.active {
+				background-color: ${({ theme }) => theme.color.surface};
+			}
 
-      &.disabled {
-        opacity: 0.5;
-        pointer-events: none;
-      }
-    }
-  }
+			&.disabled {
+				opacity: 0.5;
+				pointer-events: none;
+			}
+		}
+	}
 
-  @media screen and ${({ theme }) => theme.mediaQuery.tablet} {
-    ul {
-      display: flex;
-      flex-direction: column;
+	@media screen and ${({ theme }) => theme.mediaQuery.tablet} {
+		ul {
+			display: flex;
+			flex-direction: column;
 
-      li.prev-next {
-        padding: 1.5rem 1rem;
-        gap: 1rem;
+			li.prev-next {
+				padding: 1.5rem 1rem;
+				gap: 1rem;
 
-        .img {
-          display: none;
-        }
-      }
-    }
-  }
+				.img {
+					display: none;
+				}
+			}
+		}
+	}
 `;
 
 export default PrevNextArticle;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import type { Metadata } from 'next';
 import { fetchUserWithSubscription } from '@/api/user';
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import styled from 'styled-components';
 import Title from '@/components/common/Title';
 import Button from '@/components/common/Button';
@@ -13,11 +12,10 @@ const NotFoundPage = () => {
 				404 - 페이지를 찾을 수 없습니다.
 			</Title>
 			<Text size="large">죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</Text>
-			<Link href="/">
-				<Button as="a" size="medium" scheme="primary">
-					홈으로 돌아가기
-				</Button>
-			</Link>
+
+			<Button size="medium" scheme="primary" onClick={() => window.history.back()}>
+				이전 페이지로 돌아가기
+			</Button>
 		</StyledNotFound>
 	);
 };
@@ -32,7 +30,7 @@ const StyledNotFound = styled.div`
 	text-align: center;
 	margin-top: 2rem;
 
-	a {
+	button {
 		margin-top: 1rem;
 	}
 `;

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -20,73 +20,49 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data 
 			<div className="card-body">
 				{type === 'main' && (
 					<>
-						<div className="card-header">
-							<Text size="medium" color="primary" weight="semiBold">
-								{header}
-							</Text>
-							{main.title && (
-								<Title className="title" weight="semiBold">
-									{main.title}
-								</Title>
-							)}
-						</div>
-						<div className="card-main">
-							<div className="content">
-								{main.description && (
-									<Text className="description" size="medium">
-										{main.description}
-									</Text>
+						<Link href={url || '/not-found'}>
+							<div className="card-header">
+								<Text size="medium" color="primary" weight="semiBold">
+									{header}
+								</Text>
+								{main.title && (
+									<Title className="title" weight="semiBold">
+										{main.title}
+									</Title>
 								)}
-								{footer && <div className="card-footer">{footer}</div>}
 							</div>
-							{image && (
-								<div className="image-placeholder">
-									<Imgae src={image} alt={main.title || 'card'} />
+							<div className="card-main">
+								<div className="content">
+									{main.description && (
+										<Text className="description" size="medium">
+											{main.description}
+										</Text>
+									)}
+									{footer && (
+										<div className="card-footer" onClick={(e) => e.preventDefault()}>
+											{footer}
+										</div>
+									)}
 								</div>
-							)}
-						</div>
-					</>
-				)}
-
-				{type === 'sub' && (
-					<>
-						{url && (
-							<Link href={url}>
 								{image && (
 									<div className="image-placeholder">
 										<Imgae src={image} alt={main.title || 'card'} />
 									</div>
 								)}
-							</Link>
-						)}
-						<div className="card-header">
-							{header && (
-								<Text size="small" color="primary" weight="semiBold">
-									{header}
-								</Text>
-							)}
-						</div>
-						<div className="card-main">
-							<div className="content">
-								{main.title && (
-									<Text className="title" size="large" weight="semiBold">
-										{main.title}
-									</Text>
-								)}
-								{main.description && (
-									<Text className="description" size="small">
-										{main.description}
-									</Text>
-								)}
 							</div>
-						</div>
-						{footer && <div className="card-footer">{footer}</div>}
+						</Link>
 					</>
 				)}
 
-				{type === 'list' && (
+				{type === 'sub' && (
 					<>
-						<div className="card-main">
+						<Link href={url || '/not-found'}>
+							{image && (
+								<div className="image-placeholder">
+									<Imgae src={image} alt={main.title || 'card'} />
+								</div>
+							)}
+
 							<div className="card-header">
 								{header && (
 									<Text size="small" color="primary" weight="semiBold">
@@ -94,25 +70,60 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data 
 									</Text>
 								)}
 							</div>
-							<div className="content">
-								{main.title && (
-									<Text className="title" size="medium" weight="semiBold">
-										{main.title}
-									</Text>
-								)}
-								{main.description && (
-									<Text className="description" size="small">
-										{main.description}
-									</Text>
-								)}
-								{footer && <div className="card-footer">{footer}</div>}
+							<div className="card-main">
+								<div className="content">
+									{main.title && (
+										<Text className="title" size="large" weight="semiBold">
+											{main.title}
+										</Text>
+									)}
+									{main.description && (
+										<Text className="description" size="small">
+											{main.description}
+										</Text>
+									)}
+								</div>
 							</div>
-						</div>
-						{image && (
-							<div className="image-placeholder">
-								<Imgae src={image} alt={main.title || 'card'} />
+						</Link>
+						{footer && <div className="card-footer">{footer}</div>}
+					</>
+				)}
+
+				{type === 'list' && (
+					<>
+						<Link href={url || '/not-found'}>
+							<div className="card-main">
+								<div className="card-header">
+									{header && (
+										<Text size="small" color="primary" weight="semiBold">
+											{header}
+										</Text>
+									)}
+								</div>
+								<div className="content">
+									{main.title && (
+										<Text className="title" size="medium" weight="semiBold">
+											{main.title}
+										</Text>
+									)}
+									{main.description && (
+										<Text className="description" size="small">
+											{main.description}
+										</Text>
+									)}
+									{footer && (
+										<div className="card-footer" onClick={(e) => e.preventDefault()}>
+											{footer}
+										</div>
+									)}
+								</div>
 							</div>
-						)}
+							{image && (
+								<div className="image-placeholder">
+									<Imgae src={image} alt={main.title || 'card'} />
+								</div>
+							)}
+						</Link>
 					</>
 				)}
 			</div>
@@ -136,6 +147,7 @@ const StyledCard = styled.div<StyledProps>`
 	.image-placeholder {
 		width: 100%;
 		aspect-ratio: 16 / 9;
+		position: relative;
 		overflow: hidden;
 		border-radius: ${({ theme }) => theme.borderRadius.medium};
 		background: ${({ theme }) => theme.color.surface};
@@ -146,9 +158,15 @@ const StyledCard = styled.div<StyledProps>`
 		display: flex;
 		flex-direction: column;
 
-		&:hover img {
-			transform: scale(1.05);
-			transition: transform 0.3s ease;
+		&:hover:not(:has(.card-footer:hover)) {
+			img {
+				transform: scale(1.05);
+				transition: transform 0.3s ease;
+			}
+
+			.title {
+				color: ${({ theme }) => theme.color.primary};
+			}
 		}
 
 		.card-header {
@@ -197,10 +215,12 @@ const StyledCard = styled.div<StyledProps>`
 	}
 
 	.card-footer {
+		width: 100%;
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
 		color: ${({ theme }) => theme.color.subText};
+		cursor: default;
 
 		span {
 			font-size: ${({ theme }) => theme.fontSize.small};
@@ -282,10 +302,18 @@ const subCardStyles = css`
 `;
 
 const listCardStyles = css`
-	.image-placeholder {
-		height: 100%;
-		max-width: 30%;
+	a {
+		width: 100%;
+		display: flex;
+		flex-direction: row;
+		padding: 0;
+		margin: 0;
+		gap: 0.5rem;
+	}
 
+	.image-placeholder {
+		height: fit-content;
+		max-width: 30%;
 		@media ${({ theme }) => theme.mediaQuery.tablet} {
 			max-width: 100%;
 		}

--- a/src/components/layout/header/Navigation.tsx
+++ b/src/components/layout/header/Navigation.tsx
@@ -80,7 +80,6 @@ const StyledNavigation = styled.nav`
 
 			.sub-navigation {
 				width: 100vw;
-
 				position: fixed;
 				top: 3rem;
 				left: 0;
@@ -90,6 +89,7 @@ const StyledNavigation = styled.nav`
 				flex-direction: row;
 				justify-content: center;
 				align-items: center;
+				padding: 0 1rem;
 
 				background: ${({ theme }) => theme.color.surface};
 				border-top: 1px solid ${({ theme }) => theme.color.border};

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -39,14 +39,7 @@ export const API_ENDPOINTS = {
 		PAGINATED: (page: number, limit: number) => `${API_URL}/newsletters?page=${page}&limit=${limit}`,
 		LIST: (limit: number, offset: number) => `${API_URL}/newsletters?limit=${limit}&offset=${offset}`,
 		SUMMARIZE: () => `${API_URL}/ai-summary/summarize`,
-	},
-	MAIL: {
-		SEND: () => `${API_URL}/mail/send`,
-	},
-	AI_LOG: {
-		BASE: () => `${API_URL}/ai/log`,
-		PAGINATED: (newsId: number, page: number, limit: number) =>
-			`${API_URL}/ai/log?newsId=${newsId}&page=${page}&limit=${limit}`,
+		TRENDS: (category?: number) => `${API_URL}/newsletters/trends` + (category ? `?categoryId=${category}` : ''),
 	},
 	FEEDBACK: {
 		BASE: () => `${API_URL}/feedback`,
@@ -60,7 +53,7 @@ export const API_ENDPOINTS = {
 	CATEGORY: {
 		BASE: `${API_URL}/category`,
 		GET_BY_ID: (id: string) => `${API_URL}/category/${id}`,
-	}
+	},
 };
 
 export default API_ENDPOINTS;

--- a/src/hooks/useArticle.ts
+++ b/src/hooks/useArticle.ts
@@ -1,5 +1,5 @@
 import { fetchArticle, fetchArticleList } from '@/api/article';
-import { IArticleInfo, IArticleDetail } from '@/models/article.model';
+import { ArticleInfo as IArticleInfo, ArticleDetail as IArticleDetail } from '@/models/article.model';
 
 /**
  * 특정 기사(slug) 내용을 가져오는 함수

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -52,7 +52,7 @@ export const useAuth = () => {
 	} = useQuery<User | null>({
 		queryKey: ['user'],
 		queryFn: fetchUser,
-		enabled: true,
+		enabled: !!user,
 		staleTime: AUTH.STALE_TIME,
 		retry: 1,
 	});

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -1,56 +1,55 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { IBookmarkItem } from '@/models/bookmark.model';
-import {
-  fetchUserBookmarksApi,
-  addBookmarkApi,
-  removeBookmarkApi,
-} from '@/api/bookmark';
+import { fetchUserBookmarksApi, addBookmarkApi, removeBookmarkApi } from '@/api/bookmark';
+import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/useToast';
 
 interface BookmarkVariables {
-  newsId: number;
-  newsletterId: number;
+	newsId: number;
+	newsletterId: number;
 }
 
 // 북마크 목록 조회
 export const useBookmarksList = () => {
+	const { user } = useAuth();
 
-  return useQuery<IBookmarkItem[]>({
-    queryKey: ['bookmarks'],
-    queryFn: async () => {
-      return fetchUserBookmarksApi();
-    },
-  });
-}
+	return useQuery<IBookmarkItem[]>({
+		queryKey: ['bookmarks', user?.id],
+		queryFn: async () => {
+			return fetchUserBookmarksApi();
+		},
+		enabled: !!user,
+	});
+};
 
 // 북마크 추가
 export const useAddBookmarkMutation = () => {
-  const { showToast } = useToast();
-  const queryClient = useQueryClient();
+	const { showToast } = useToast();
+	const queryClient = useQueryClient();
 
-  return useMutation<IBookmarkItem, Error, BookmarkVariables>({
-    mutationFn: async ({ newsId, newsletterId }) => {
-      return addBookmarkApi(newsId, newsletterId);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
-      showToast('북마크가 추가되었습니다.', 'success');
-    },
-  });
-}
+	return useMutation<IBookmarkItem, Error, BookmarkVariables>({
+		mutationFn: async ({ newsId, newsletterId }) => {
+			return addBookmarkApi(newsId, newsletterId);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+			showToast('북마크가 추가되었습니다.', 'success');
+		},
+	});
+};
 
 // 북마크 삭제
 export const useRemoveBookmarkMutation = () => {
-  const { showToast } = useToast();
-  const queryClient = useQueryClient();
+	const { showToast } = useToast();
+	const queryClient = useQueryClient();
 
-  return useMutation<{ success: boolean }, Error, BookmarkVariables>({
-    mutationFn: async ({ newsId, newsletterId }) => {
-      return removeBookmarkApi(newsId, newsletterId);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
-      showToast('북마크가 삭제되었습니다.', 'success');
-    },
-  });
-}
+	return useMutation<{ success: boolean }, Error, BookmarkVariables>({
+		mutationFn: async ({ newsId, newsletterId }) => {
+			return removeBookmarkApi(newsId, newsletterId);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+			showToast('북마크가 삭제되었습니다.', 'success');
+		},
+	});
+};

--- a/src/hooks/useMySubscribe.ts
+++ b/src/hooks/useMySubscribe.ts
@@ -1,23 +1,24 @@
-import { IArticleDetail } from '@/models/article.model';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import { fetchArticleList } from '@/api/article';
 import { dateFormatter } from '@/utils/formatter';
 
-
 export const getTodayArticles = async (limit: number = 100) => {
-  const data = await fetchArticleList(limit, 0);
-  const newsletters: IArticleDetail[] = data.data;
+	const data = await fetchArticleList(limit, 0);
+	const newsletters: IArticleDetail[] = data.data;
 
-  const now = new Date();
-  const yesterday = new Date(now.setDate(now.getDate() - 1));
+	const now = new Date();
+	const yesterday = new Date(now.setDate(now.getDate() - 1));
 
-  const TodayNewsletter = newsletters.filter((n) => dateFormatter(n.createdAt) === dateFormatter(yesterday.toString()));
+	const TodayNewsletter = newsletters.filter(
+		(n) => dateFormatter(n.createdAt) === dateFormatter(yesterday.toString())
+	);
 
-  return TodayNewsletter;
+	return TodayNewsletter;
 };
 
 export const userSubscribeArticles = async (categoryId: number[]) => {
-  const todayNewsletter: IArticleDetail[] = await getTodayArticles(100);
-  const userArticle = todayNewsletter.filter((n) => categoryId.includes(n.categoryId));
+	const todayNewsletter: IArticleDetail[] = await getTodayArticles(100);
+	const userArticle = todayNewsletter.filter((n) => categoryId.includes(n.categoryId));
 
-  return userArticle;
-}
+	return userArticle;
+};

--- a/src/models/article.model.ts
+++ b/src/models/article.model.ts
@@ -1,28 +1,37 @@
-export interface IArticleInfo {
-  newsletter: IArticleDetail;
-  previousNewsletter: IArticleDetail | null;
-  nextNewsletter: IArticleDetail | null;
+export interface ArticleInfo {
+	newsletter: ArticleDetail;
+	previousNewsletter: ArticleDetail | null;
+	nextNewsletter: ArticleDetail | null;
 }
 
-export interface IArticleDetail {
-  id: number;
-  title: string;
-  content: string;
-  contentAsHTML: string;
-  imageUrl: string | null;
-  categoryId: number;
-  viewcount: number;
-  usedNews: string;
-  createdAt: string;
+export interface ArticleDetail {
+	id: number;
+	title: string;
+	content: string;
+	contentAsHTML: string;
+	imageUrl: string | null;
+	categoryId: number;
+	viewcount: number;
+	usedNews: string;
+	createdAt: string;
 }
 
-export interface IMySummary {
-  id: number;
-  categoryName: string;
-  userId: number;
-  createdAt: string;
-  img: string;
-  like: number;
-  title: string;
-  summary: string;
+export interface ArticleSummary {
+	id: number;
+	categoryName: string;
+	userId: number;
+	img: string;
+	title: string;
+	summary: string;
+	like: number;
+	createdAt: string;
+}
+
+export interface ArticleCard {
+	id: number;
+	categoryName: string;
+	image: string;
+	title: string;
+	summary: string;
+	date: string;
 }

--- a/src/stores/useMySubscribeStore.ts
+++ b/src/stores/useMySubscribeStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { IArticleDetail } from '@/models/article.model';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import { userSubscribeArticles } from '@/hooks/useMySubscribe';
 
 interface ArticleStore {


### PR DESCRIPTION
## 작업 개요
홈 화면에 오늘의 트렌드 데이터를 불러오는 기능을 추가하였으며, 몇 가지 디자인 및 기능적 수정 사항을 적용하였습니다.  

## PR 유형  
- [x] 새로운 기능 추가  
- [x] 버그 수정  
- [x] 코드 리팩토링  
- [x] 디자인 수정  

## 주요 변경 사항  
- **홈 화면에서 오늘의 트렌드 데이터를 불러오기**  
  - `page.tsx`에서 `trendsData`를 활용하여 트렌드 섹션을 동적으로 렌더링  
- **카드 컴포넌트에서 이미지 이외의 영역을 클릭해도 링크 이동 가능하도록 수정**  
- **루트 레이아웃 동적 렌더링 적용** -> build 시 에러 수정
- **Query enabled 조건 추가**  
  - `user`가 존재할 때만 `fetchUser` 및 `bookmark` 실행하도록 수정  

### 기타 변경 사항
- not-found 페이지의 액션 버튼을 "홈으로 돌아가기"에서 "이전 페이지로 돌아가기"로 변경
- 에러 메시지 문구 개선
- 서브 네비게이션에 `padding` 추가  

## 변경 이유  
- 홈 화면의 콘텐츠를 동적으로 업데이트

## 테스트 결과

![Screenshot 2025-02-03 at 09 24 45](https://github.com/user-attachments/assets/5cdff510-3611-40d3-a913-8cb14fb8ff2d)

- [x] 홈 화면에서 트렌드 데이터가 정상적으로 로드 되는지 확인  
- [x] 카드 컴포넌트에서 이미지 이외의 영역(footer 제외)을 클릭해도 정상적으로 이동하는지 확인  
- [x] not-found 페이지의 액션 버튼이 정상적으로 동작하는지 확인  
- [x] `fetchUser` 및 `bookmark`가 `user`가 존재할 때만 실행되는지 확인  