### PR TITLE
[Feature] 조회수 기능 추가 및 카테고리 페이지 정렬 수정

### DIFF
--- a/src/api/view.ts
+++ b/src/api/view.ts
@@ -1,0 +1,22 @@
+import { API_ENDPOINTS } from '@/constants/api';
+
+export const increaseViewCount = async (newsletterId: number) => {
+	try {
+		const response = await fetch(API_ENDPOINTS.NEWSLETTER.VIEW_COUNT(newsletterId), {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		});
+
+		if (!response.ok) {
+			throw new Error(`Error: ${response.status} ${response.statusText}`);
+		}
+
+		return await response.json();
+	} catch (error) {
+		console.error('Failed to summarize news:', error);
+		throw error;
+	}
+};

--- a/src/app/(home)/_components/TrendSection.tsx
+++ b/src/app/(home)/_components/TrendSection.tsx
@@ -46,6 +46,7 @@ const TrendSection = ({ trends = [] }: Props) => {
 									footer: (
 										<>
 											<Text color="subText">{trend.date}</Text>
+											<Text color="subText">|&nbsp;&nbsp;조회수 {trend.views}</Text>
 											<div className="right">
 												<BookmarkIcon newsId={trend.id} newsletterId={trend.id} />
 											</div>

--- a/src/app/articles/(main)/_components/HotSection.tsx
+++ b/src/app/articles/(main)/_components/HotSection.tsx
@@ -51,6 +51,7 @@ export default function HotSection({ trends: initiallData = [] }: Props) {
 					footer: (
 						<>
 							<Text color="subText">{trend.date}</Text>
+							<Text color="subText">|&nbsp;&nbsp;조회수 {trend.views}</Text>
 							<div className="right">
 								<BookmarkIcon newsId={trend.id} newsletterId={trend.id} />
 							</div>

--- a/src/app/articles/(main)/_components/ListSection.tsx
+++ b/src/app/articles/(main)/_components/ListSection.tsx
@@ -138,10 +138,10 @@ export default function ListSection() {
 					</Button>
 					<Button
 						style={{ width: '6rem' }}
-						data-active={selectedSort === 'bookmarks'}
-						onClick={() => setSelectedSort('bookmarks')}
+						data-active={selectedSort === 'views'}
+						onClick={() => setSelectedSort('views')}
 					>
-						북마크순
+						인기순
 					</Button>
 				</div>
 			</div>

--- a/src/app/articles/(main)/_components/ListSection.tsx
+++ b/src/app/articles/(main)/_components/ListSection.tsx
@@ -164,7 +164,7 @@ export default function ListSection() {
 							footer: (
 								<>
 									<Text color="subText">{article.date}</Text>
-
+									<Text color="subText">|&nbsp;&nbsp;조회수 {article.views}</Text>
 									<div className="right">
 										<BookmarkIcon newsId={article.id} newsletterId={article.id} />
 									</div>

--- a/src/app/articles/detail/[slug]/_components/Article.tsx
+++ b/src/app/articles/detail/[slug]/_components/Article.tsx
@@ -63,7 +63,7 @@ function Article({ viewCount, article, summary, content, popular, latest, newsId
 							{dateFormatter(article.createdAt)}
 						</Text>
 						<Text size="small" color="subText">
-							조회수 | {viewCount}
+							|&nbsp;&nbsp;조회수 {viewCount}
 						</Text>
 					</div>
 					<div className="icons">
@@ -183,7 +183,7 @@ const TitleSectionStyled = styled.div`
 			flex-direction: row;
 			justify-content: center;
 			align-items: center;
-			gap: 1rem;
+			gap: 0.5rem;
 		}
 	}
 `;

--- a/src/app/articles/detail/[slug]/_components/Article.tsx
+++ b/src/app/articles/detail/[slug]/_components/Article.tsx
@@ -1,24 +1,28 @@
-'use client'
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { ArticleDetail as IArticleDetail } from '@/models/article.model';
+import { dateFormatter } from '@/utils/formatter';
+import { useCategoryStore } from '@/stores/useCategoryStore';
 
 import styled from 'styled-components';
+import { IoArrowBack } from 'react-icons/io5';
+import Text from '@/components/common/Text';
 import SummaryTextBox from '@/components/common/article/SummaryTextBox';
 import PopularArticle from '@/app/articles/detail/[slug]/_components/PopularArticle';
 import ArticleContent from '@/app/articles/detail/[slug]/_components/content/ArticleContent';
 import PrevNextArticle from '@/app/articles/detail/[slug]/_components/PrevNextArticle';
 import LatestArticle from '@/app/articles/detail/[slug]/_components/LatestArticle';
 import MobileLikeLinkButton from '@/app/articles/detail/[slug]/_components/MobileLikeLinkButton';
-import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import MoveButton from '@/components/common/MoveButton';
-import { IoArrowBack } from 'react-icons/io5';
-import Link from 'next/link';
 import BookmarkIcon from '@/components/common/icons/BookmarkIcon';
 import LinkCopyIcon from '@/components/common/icons/LinkCopyIcon';
-import { useRouter } from 'next/navigation';
-import { useCategoryStore } from '@/stores/useCategoryStore';
-import { useEffect } from 'react';
-import { dateFormatter } from '@/utils/formatter';
+import Title from '@/components/common/Title';
 
 interface Props {
+	viewCount: number;
 	article: IArticleDetail;
 	summary: string;
 	content: string;
@@ -29,143 +33,159 @@ interface Props {
 	next: IArticleDetail | null;
 }
 
-function Article({ article, summary, content, popular, latest, newsId, prev, next }: Props) {
+function Article({ viewCount, article, summary, content, popular, latest, newsId, prev, next }: Props) {
 	const router = useRouter();
 	const { categories, fetchCategories, getCategoryName } = useCategoryStore();
 
-  useEffect(() => {
-    if (Object.keys(categories).length === 0) {
-      fetchCategories();
-    }
-  }, [categories, fetchCategories]);
+	useEffect(() => {
+		if (Object.keys(categories).length === 0) {
+			fetchCategories();
+		}
+	}, [categories, fetchCategories]);
 
-  return (
-    <>
-      <TitleSectionStyled>
-        <MoveButton onClick={() => router.push(`/articles?categoryId=${article.categoryId}`)} text="목록으로" frontIcon={<IoArrowBack />} />
-        <div className="title-section">
-          <Link href={`/articles?categoryId=${article.categoryId}`} className="category">{getCategoryName(article.categoryId)}</Link>
-          <h1 className="title">{article.title}</h1>
-          <p className="date">{dateFormatter(article.createdAt)}</p>
-          <div className="icons">
-            <BookmarkIcon newsId={article.id} newsletterId={article.id} />
-            <LinkCopyIcon id={article.id} />
-          </div>
-        </div>
-      </TitleSectionStyled>
-      <ArticleStyled>
-        <SummaryTextBox>{summary}</SummaryTextBox>
-        <div className="content-section">
-          <ArticleContent className="content" content={content} articleImage={article.imageUrl ?? ""} />
-          <PopularArticle className="popular" popular={popular} />
-        </div>
-        <PrevNextArticle className="prev-next" prev={prev} next={next} />
-        {/*<CommentsSection className="comments-section"/>*/}
-        <LatestArticle className="latest" latest={latest} />
-        <MobileLikeLinkButton className="icons" newsId={newsId} />
-      </ArticleStyled>
-    </>
-  );
+	return (
+		<>
+			<TitleSectionStyled>
+				<MoveButton
+					onClick={() => router.push(`/articles?categoryId=${article.categoryId}`)}
+					text="목록으로"
+					frontIcon={<IoArrowBack />}
+				/>
+				<div className="title-section">
+					<Link href={`/articles?categoryId=${article.categoryId}`} className="category">
+						{getCategoryName(article.categoryId)}
+					</Link>
+					<Title size="large" weight="semiBold" className="title">
+						{article.title}
+					</Title>
+					<div className="info">
+						<Text size="small" color="subText">
+							{dateFormatter(article.createdAt)}
+						</Text>
+						<Text size="small" color="subText">
+							조회수 | {viewCount}
+						</Text>
+					</div>
+					<div className="icons">
+						<BookmarkIcon newsId={article.id} newsletterId={article.id} />
+						<LinkCopyIcon id={article.id} />
+					</div>
+				</div>
+			</TitleSectionStyled>
+			<ArticleStyled>
+				<SummaryTextBox>{summary}</SummaryTextBox>
+				<div className="content-section">
+					<ArticleContent className="content" content={content} articleImage={article.imageUrl ?? ''} />
+					<PopularArticle className="popular" popular={popular} />
+				</div>
+				<PrevNextArticle className="prev-next" prev={prev} next={next} />
+				{/*<CommentsSection className="comments-section"/>*/}
+				<LatestArticle className="latest" latest={latest} />
+				<MobileLikeLinkButton className="icons" newsId={newsId} />
+			</ArticleStyled>
+		</>
+	);
 }
 
 const ArticleStyled = styled.div`
-    margin: 4rem 0;
-    position: relative;
-    width: 100%;
-    height: auto;
+	margin: 4rem 0;
+	position: relative;
+	width: 100%;
+	height: auto;
 
-    .content-section {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-start;
-        gap: 2rem;
-        margin: 2rem 0;
+	.content-section {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+		gap: 2rem;
+		margin: 2rem 0;
 
-        .content {
-            flex: 3;
-        }
+		.content {
+			flex: 3;
+		}
 
-        .popular {
-            flex: 1;
-            margin-top: 2rem;
-        }
-    }
+		.popular {
+			flex: 1;
+			margin-top: 2rem;
+		}
+	}
 
-    .comments-section {
-        margin: 4rem 0;
-    }
+	.comments-section {
+		margin: 4rem 0;
+	}
 
-    @media screen and ${({ theme }) => theme.mediaQuery.tablet} {
-        display: flex;
-        flex-direction: column;
+	@media screen and ${({ theme }) => theme.mediaQuery.tablet} {
+		display: flex;
+		flex-direction: column;
 
-        .content-section {
-            flex-direction: column;
+		.content-section {
+			flex-direction: column;
 
-            .content {
-                border-bottom: 1px solid ${({ theme }) => theme.color.border};
-                margin-bottom: 2rem;
-            }
+			.content {
+				border-bottom: 1px solid ${({ theme }) => theme.color.border};
+				margin-bottom: 2rem;
+			}
 
-            .popular {
-                order: 4;
-            }
-        }
-    }
+			.popular {
+				order: 4;
+			}
+		}
+	}
 
-    .induce {
-        order: 1;
-    }
+	.induce {
+		order: 1;
+	}
 
-    .prev-next {
-        order: 2;
-    }
+	.prev-next {
+		order: 2;
+	}
 
-    .latest {
-        order: 3;
-    }
+	.latest {
+		order: 3;
+	}
 `;
 
-
 const TitleSectionStyled = styled.div`
-    margin-top: 4rem;
-    display: flex;
-    flex-direction: column;
-    border-bottom: 1px solid ${({ theme }) => theme.color.border};
+	margin-top: 4rem;
+	display: flex;
+	flex-direction: column;
+	border-bottom: 1px solid ${({ theme }) => theme.color.border};
 
-    .title-section {
-        text-align: center;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        gap: 0.25rem;
-        margin: 1.25rem 0;
+	.title-section {
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		gap: 0.25rem;
+		margin: 1.25rem 0;
 
-        .category {
-            color: ${({ theme }) => theme.color.primary};
-            font-weight: ${({ theme }) => theme.fontWeight.medium};
-        }
+		.category {
+			color: ${({ theme }) => theme.color.primary};
+			font-weight: ${({ theme }) => theme.fontWeight.medium};
+		}
 
-        .title {
-            word-break: auto-phrase;
-        }
+		.title {
+			word-break: auto-phrase;
+		}
 
-        .icons {
-            display: flex;
-            flex-direction: row;
-            gap: 1rem;
-            justify-content: center;
-            align-items: center;
-            margin-top: 0.75rem;
-        }
+		.icons {
+			display: flex;
+			flex-direction: row;
+			gap: 1rem;
+			justify-content: center;
+			align-items: center;
+			margin-top: 0.75rem;
+		}
 
-        .date {
-            color: ${({ theme }) => theme.color.lightGrey};
-            font-size: ${({ theme }) => theme.fontSize.extraSmall};
-        }
-    }
-
+		.info {
+			display: flex;
+			flex-direction: row;
+			justify-content: center;
+			align-items: center;
+			gap: 1rem;
+		}
+	}
 `;
 
 export default Article;

--- a/src/app/articles/detail/[slug]/page.tsx
+++ b/src/app/articles/detail/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Article from '@/app/articles/detail/[slug]/_components/Article';
 import { stripCodeFence } from '@/utils/stripCodeFence';
 import { getArticleContent, getArticleList, getPopularArticles } from '@/hooks/useArticle';
+import { increaseViewCount } from '@/api/view';
 
 type PageParams = Promise<{ slug: string }>;
 
@@ -14,9 +15,12 @@ export default async function NewsletterDetailPage({ params }: { params: PagePar
 	const popularArticles = await getPopularArticles(5, 0, true);
 	const latestArticles = await getArticleList(9);
 
+	const viewCount = await increaseViewCount(articleContent.id);
+
 	return (
 		<>
 			<Article
+				viewCount={viewCount.data}
 				article={articleContent}
 				summary={articleContent.content ? articleContent.content : ''}
 				content={articleContentHTML}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -43,6 +43,7 @@ export const API_ENDPOINTS = {
 		TRENDS: (category?: number) => `${API_URL}/newsletters/trends` + (category ? `?categoryId=${category}` : ''),
 		POPULAR: (limit: number, offset: number, popular: boolean) =>
 			`${API_URL}/newsletters?limit=${limit}&offset=${offset}&popular=${popular}`,
+		VIEW_COUNT: (newsletterId: number) => `${API_URL}/newsletters/viewcount/${newsletterId}`,
 		SUMMARIZE: () => `${API_URL}/ai-summary/summarize`,
 	},
 	FEEDBACK: {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -33,6 +33,7 @@ export const API_ENDPOINTS = {
 	},
 	NEWSLETTER: {
 		BASE: `${API_URL}/newsletters`,
+		VIEW_COUNT: (newsletterId: number) => `${API_URL}/newsletters/viewcount/${newsletterId}`,
 		PAGINATED: (page: number, limit: number) => `${API_URL}/newsletters?page=${page}&limit=${limit}`,
 		LIST: (limit: number, offset: number, popular?: boolean) =>
 			popular
@@ -43,7 +44,6 @@ export const API_ENDPOINTS = {
 		TRENDS: (category?: number) => `${API_URL}/newsletters/trends` + (category ? `?categoryId=${category}` : ''),
 		POPULAR: (limit: number, offset: number, popular: boolean) =>
 			`${API_URL}/newsletters?limit=${limit}&offset=${offset}&popular=${popular}`,
-		VIEW_COUNT: (newsletterId: number) => `${API_URL}/newsletters/viewcount/${newsletterId}`,
 		SUMMARIZE: () => `${API_URL}/ai-summary/summarize`,
 	},
 	FEEDBACK: {


### PR DESCRIPTION
## 작업 개요  

**detail 페이지에 조회수 기능을 적용**하고, **카테고리 페이지에서 인기순(조회수 순) 정렬을 추가**하였습니다.

---

### PR 유형  
- [x] 새로운 기능 추가  

---

### 주요 변경 사항  
- **detail 페이지 조회수 적용**:  
  - 상세 페이지 방문 시 조회수가 증가하도록 기능 추가

- **카테고리 페이지에서 북마크순 > 인기순(조회수순) 정렬로 수정**:  
  - 카테고리 페이지에서 조회수 기준으로 인기 뉴스 정렬 가능하도록 수정

- **카드 컴포넌트**에 조회수 표시

---

### 변경 이유  
- 사용자들이 인기 뉴스 기준으로 정렬할 수 있도록 선택지를 제공  

---

### 테스트 결과  

![Screenshot 2025-02-04 at 21 12 52](https://github.com/user-attachments/assets/2c0dab45-ef72-4842-bf9f-597d6570beec)
- [x] detail 페이지 방문 시 조회수가 정상적으로 증가하는지 확인

![Screenshot 2025-02-04 at 21 24 29](https://github.com/user-attachments/assets/e41b48a7-d47e-4927-b721-150b047575b1)
- [x] 카테고리 페이지에서 인기순(조회수 기준) 정렬이 정상적으로 동작하는지 확인
- [x] 카드 컴포넌트와 디테일 페이지에 조회수 표시 
- [x] 기존 기능에 영향 없이 정상 동작하는지 확인  