### PR TITLE
[Feature] 상세 페이지에 관련 뉴스 미리보기 카드 추가

### DIFF
--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -56,3 +56,19 @@ export const fetchArticleByCategory = async (category: number, limit: number = 5
 
 	return await response.json();
 };
+
+export const fetchRelatedNews = async (link: string) => {
+	const response = await fetch(API_ENDPOINTS.NEWS.RELATED(link), {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	});
+
+	if (!response.ok) {
+		throw new Error('관련 뉴스를 불러오는데 실패했습니다.');
+	}
+
+	const news = await response.json();
+	return news.data;
+};

--- a/src/app/(protected)/mypage/_components/settings/StartSubscription.tsx
+++ b/src/app/(protected)/mypage/_components/settings/StartSubscription.tsx
@@ -85,7 +85,7 @@ export default function StartSubscription() {
 					)}
 				</div>
 				<Text size="small" color="subText">
-					구독할 괌심사를 선택한 후 완료 버튼을 눌러주세요.
+					구독할 관심사를 선택한 후 완료 버튼을 눌러주세요.
 					<br />
 					{isSubscribed !== null && '내일 보내드리는 뉴스레터부터 적용됩니다.'}
 				</Text>

--- a/src/app/articles/(main)/_components/HotSection.tsx
+++ b/src/app/articles/(main)/_components/HotSection.tsx
@@ -27,16 +27,15 @@ export default function HotSection({ trends: initiallData = [] }: Props) {
 
 	return (
 		<StyledHotSection $isAll={categoryName === '전체'}>
+			<Title size="large" weight="semiBold">
+				{categoryName} 뉴스레터
+			</Title>
+			<hr />
 			<div className="title">
 				<Title size="extraSmall" color="primary" weight="bold" className="tag">
 					{searchParams ? 'TODAY' : 'HOT'}
 				</Title>
-				<Title size="extraSmall" weight="semiBold">
-					{categoryName} 뉴스레터
-				</Title>
 			</div>
-			<hr />
-
 			<CardSlider
 				className="card-slider"
 				type="main"
@@ -76,7 +75,7 @@ const StyledHotSection = styled.section<StyledProps>`
 	justify-content: space-between;
 	align-items: flex-start;
 	gap: 1rem;
-	padding: 3rem 0;
+	padding: 1rem 0;
 
 	hr {
 		width: 100%;
@@ -101,6 +100,8 @@ const StyledHotSection = styled.section<StyledProps>`
 	}
 
 	.card-slider {
+		padding: 0 0.5rem;
+
 		.controls {
 			display: ${({ $isAll }) => ($isAll ? 'flex' : 'none')};
 		}

--- a/src/app/articles/(main)/_components/ListSection.tsx
+++ b/src/app/articles/(main)/_components/ListSection.tsx
@@ -145,9 +145,8 @@ export default function ListSection() {
 					</Button>
 				</div>
 			</div>
-
+			<hr />
 			<div className="newsletter-cards">
-				<hr />
 				{sortedArticles.map((article, index) => (
 					<Card
 						type="list"
@@ -189,6 +188,14 @@ const StyledListSection = styled.section`
 	justify-content: space-between;
 	align-items: flex-start;
 	gap: 1rem;
+
+	hr {
+		width: 100%;
+		border: none;
+		margin: 0;
+		padding: 0;
+		border-bottom: 1px solid ${({ theme }) => theme.color.border};
+	}
 
 	.header {
 		width: 100%;

--- a/src/app/articles/(main)/_components/ListSection.tsx
+++ b/src/app/articles/(main)/_components/ListSection.tsx
@@ -124,28 +124,16 @@ export default function ListSection() {
 					<Title size="extraSmall" weight="semiBold" color="primary" className="tag">
 						전체
 					</Title>
-					<Title size="extraSmall" weight="semiBold">
-						{categoryName} 뉴스레터
-					</Title>
 				</div>
 				<div className="right-section">
-					<Button
-						style={{ width: '6rem' }}
-						data-active={selectedSort === 'latest'}
-						onClick={() => setSelectedSort('latest')}
-					>
+					<Button data-active={selectedSort === 'latest'} onClick={() => setSelectedSort('latest')}>
 						최신순
 					</Button>
-					<Button
-						style={{ width: '6rem' }}
-						data-active={selectedSort === 'views'}
-						onClick={() => setSelectedSort('views')}
-					>
+					<Button data-active={selectedSort === 'views'} onClick={() => setSelectedSort('views')}>
 						인기순
 					</Button>
 				</div>
 			</div>
-			<hr />
 			<div className="newsletter-cards">
 				{sortedArticles.map((article, index) => (
 					<Card
@@ -188,6 +176,7 @@ const StyledListSection = styled.section`
 	justify-content: space-between;
 	align-items: flex-start;
 	gap: 1rem;
+	margin-top: 2rem;
 
 	hr {
 		width: 100%;
@@ -204,6 +193,14 @@ const StyledListSection = styled.section`
 		justify-content: space-between;
 		align-items: center;
 
+		@media ${({ theme }) => theme.mediaQuery.mobile} {
+			flex-wrap: wrap;
+
+			.right-section {
+				margin-top: 1rem;
+			}
+		}
+
 		.title {
 			display: flex;
 			flex-direction: row;
@@ -211,7 +208,12 @@ const StyledListSection = styled.section`
 			align-items: center;
 			gap: 1rem;
 
+			h1 {
+				white-space: nowrap;
+			}
+
 			.tag {
+				white-space: nowrap;
 				border-radius: ${({ theme }) => theme.borderRadius.capsule};
 				background: ${({ theme }) => theme.color.tertiary};
 				color: ${({ theme }) => theme.color.primary};

--- a/src/app/articles/(main)/category.module.css
+++ b/src/app/articles/(main)/category.module.css
@@ -1,5 +1,6 @@
 .categoryPage {
   gap: 2rem;
+  margin-top: 1.5rem;
   width: 100%;
 }
 

--- a/src/app/articles/(main)/page.tsx
+++ b/src/app/articles/(main)/page.tsx
@@ -1,10 +1,10 @@
 import { ArticleSummary as IArticleSummary } from '@/models/article.model';
+import { parseArticles } from '@/utils/parseArticles';
 import { fetchTrendList } from '@/api/article';
 
+import styles from '@/app/articles/(main)/category.module.css';
 import HotSection from '@/app/articles/(main)/_components/HotSection';
 import ListSection from '@/app/articles/(main)/_components/ListSection';
-import styles from '@/app/articles/(main)/category.module.css';
-import { parseArticles } from '@/utils/parseArticles';
 
 export default async function CategoryPage() {
 	let parsedTrends: IArticleSummary[] = [];

--- a/src/app/articles/detail/[slug]/_components/Article.tsx
+++ b/src/app/articles/detail/[slug]/_components/Article.tsx
@@ -29,11 +29,12 @@ interface Props {
 	popular: IArticleDetail[];
 	latest: IArticleDetail[];
 	newsId: number;
+	related: string[];
 	prev: IArticleDetail | null;
 	next: IArticleDetail | null;
 }
 
-function Article({ viewCount, article, summary, content, popular, latest, newsId, prev, next }: Props) {
+function Article({ viewCount, article, summary, content, popular, latest, newsId, related, prev, next }: Props) {
 	const router = useRouter();
 	const { categories, fetchCategories, getCategoryName } = useCategoryStore();
 
@@ -75,7 +76,13 @@ function Article({ viewCount, article, summary, content, popular, latest, newsId
 			<ArticleStyled>
 				<SummaryTextBox>{summary}</SummaryTextBox>
 				<div className="content-section">
-					<ArticleContent className="content" content={content} articleImage={article.imageUrl ?? ''} />
+					<ArticleContent
+						className="content"
+						content={content}
+						articleImage={article.imageUrl ?? ''}
+						newsId={newsId}
+						related={related}
+					/>
 					<PopularArticle className="popular" popular={popular} />
 				</div>
 				<PrevNextArticle className="prev-next" prev={prev} next={next} />

--- a/src/app/articles/detail/[slug]/_components/content/ArticleContent.tsx
+++ b/src/app/articles/detail/[slug]/_components/content/ArticleContent.tsx
@@ -9,8 +9,8 @@ import SubscribeInduce from '@/app/articles/detail/[slug]/_components/content/Su
 import HeightAutoImg from '@/components/common/HeightAutoImg';
 import Skeleton from '@/components/common/loader/Skeleton';
 import { getRelatedNews } from '@/hooks/useArticle';
-import Title from '@/components/common/Title';
 import { dateFormatter } from '@/utils/formatter';
+import { FaLink } from 'react-icons/fa';
 const LazyCard = lazy(() => import('@/components/common/Card'));
 
 interface NewsletterContentProps {
@@ -47,11 +47,15 @@ function ArticleContent({ content, flex, className, articleImage, related = [] }
 				<div dangerouslySetInnerHTML={{ __html: content }} />
 				<div className="content-bottom-margin" />
 			</NewsletterContentStyled>
+			<hr />
 			<Suspense fallback={<Skeleton />}>
 				<div className="related-news">
-					<Title size="small" weight="semiBold" className="header">
-						관련 뉴스
-					</Title>
+					<div className="header">
+						<FaLink />
+						<Text size="medium" weight="semiBold">
+							관련 뉴스
+						</Text>
+					</div>
 					{relatedNewsData.map((news) => (
 						<LazyCard
 							className="card"
@@ -89,12 +93,32 @@ const ContainerStyled = styled.div<Omit<NewsletterContentProps, 'content'>>`
 	height: 100%;
 	max-width: 100%;
 
+	hr {
+		width: 100%;
+		margin: 0;
+		border: none;
+		border-bottom: 1px solid ${({ theme }) => theme.color.border};
+	}
+
 	.related-news {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 1rem;
 		margin-top: 2rem;
 		margin-bottom: 4rem;
+
+		.header {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			margin: 0;
+			padding: 0.5rem 1rem;
+			gap: 0.5rem;
+
+			border-radius: ${({ theme }) => theme.borderRadius.capsule};
+			background: ${({ theme }) => theme.color.tertiary};
+			color: ${({ theme }) => theme.color.primary};
+		}
 
 		.card {
 			background: ${({ theme }) => theme.color.surface};
@@ -119,20 +143,13 @@ const ContainerStyled = styled.div<Omit<NewsletterContentProps, 'content'>>`
 					padding: 0;
 					margin: 0;
 					gap: 1rem;
+					border: none;
 
 					.left {
 						padding: 0;
 						margin: 0;
 					}
 				}
-			}
-
-			.header {
-				margin: 0;
-				padding: 0.25rem 1rem;
-				border-radius: ${({ theme }) => theme.borderRadius.capsule};
-				background: ${({ theme }) => theme.color.tertiary};
-				color: ${({ theme }) => theme.color.primary};
 			}
 		}
 	}

--- a/src/app/articles/detail/[slug]/_components/content/ArticleContent.tsx
+++ b/src/app/articles/detail/[slug]/_components/content/ArticleContent.tsx
@@ -1,17 +1,41 @@
 'use client';
 
+import { lazy, Suspense, useEffect, useState } from 'react';
+import { NewsInfo as INewsInfo } from '@/models/article.model';
+
 import styled from 'styled-components';
+import Text from '@/components/common/Text';
 import SubscribeInduce from '@/app/articles/detail/[slug]/_components/content/SubscribeInduce';
 import HeightAutoImg from '@/components/common/HeightAutoImg';
+import Skeleton from '@/components/common/loader/Skeleton';
+import { getRelatedNews } from '@/hooks/useArticle';
+import Title from '@/components/common/Title';
+import { dateFormatter } from '@/utils/formatter';
+const LazyCard = lazy(() => import('@/components/common/Card'));
 
 interface NewsletterContentProps {
 	content: string;
 	flex?: number;
 	className?: string;
 	articleImage?: string;
+	newsId?: number;
+	related?: string[];
 }
 
-function ArticleContent({ content, flex, className, articleImage }: NewsletterContentProps) {
+function ArticleContent({ content, flex, className, articleImage, related = [] }: NewsletterContentProps) {
+	const [relatedNewsData, setRelatedNewsData] = useState<INewsInfo[]>([]);
+
+	// 비동기 데이터를 useEffect에서 처리
+	useEffect(() => {
+		const fetchData = async () => {
+			if (related.length > 0) {
+				const data = await getRelatedNews(related);
+				setRelatedNewsData(data); // 상태 업데이트
+			}
+		};
+		fetchData();
+	}, [related]);
+
 	return (
 		<ContainerStyled flex={flex} className={className}>
 			{articleImage && (
@@ -23,6 +47,36 @@ function ArticleContent({ content, flex, className, articleImage }: NewsletterCo
 				<div dangerouslySetInnerHTML={{ __html: content }} />
 				<div className="content-bottom-margin" />
 			</NewsletterContentStyled>
+			<Suspense fallback={<Skeleton />}>
+				<div className="related-news">
+					<Title size="small" weight="semiBold" className="header">
+						관련 뉴스
+					</Title>
+					{relatedNewsData.map((news) => (
+						<LazyCard
+							className="card"
+							type="list"
+							newTab={true}
+							key={news.link}
+							data={{
+								id: news.id,
+								url: news.link,
+								image: news.images[0],
+								header: news.category[0],
+								main: {
+									title: news.title,
+									description: news.content,
+								},
+								footer: (
+									<>
+										<Text color="subText">{dateFormatter(news.publishedAt)}</Text>
+									</>
+								),
+							}}
+						/>
+					))}
+				</div>
+			</Suspense>
 			<SubscribeInduce />
 		</ContainerStyled>
 	);
@@ -34,6 +88,54 @@ const ContainerStyled = styled.div<Omit<NewsletterContentProps, 'content'>>`
 	flex-direction: column;
 	height: 100%;
 	max-width: 100%;
+
+	.related-news {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1rem;
+		margin-top: 2rem;
+		margin-bottom: 4rem;
+
+		.card {
+			background: ${({ theme }) => theme.color.surface};
+			border: 1px solid ${({ theme }) => theme.color.border};
+			border-radius: ${({ theme }) => theme.borderRadius.soft};
+			padding: 1rem;
+			gap: 0;
+
+			.card-header {
+				display: none;
+			}
+
+			.card-body {
+				border: none;
+				margin: 0;
+				padding: 0;
+				display: flex;
+				flex-direction: column;
+				justify-content: flex-start;
+
+				.content {
+					padding: 0;
+					margin: 0;
+					gap: 1rem;
+
+					.left {
+						padding: 0;
+						margin: 0;
+					}
+				}
+			}
+
+			.header {
+				margin: 0;
+				padding: 0.25rem 1rem;
+				border-radius: ${({ theme }) => theme.borderRadius.capsule};
+				background: ${({ theme }) => theme.color.tertiary};
+				color: ${({ theme }) => theme.color.primary};
+			}
+		}
+	}
 `;
 
 const NewsletterContentStyled = styled.article`

--- a/src/app/articles/detail/[slug]/page.tsx
+++ b/src/app/articles/detail/[slug]/page.tsx
@@ -16,6 +16,10 @@ export default async function NewsletterDetailPage({ params }: { params: PagePar
 	const latestArticles = await getArticleList(9);
 
 	const viewCount = await increaseViewCount(articleContent.id);
+	const usedNewsList = articleContent.usedNews
+		.split(',')
+		.map((url) => url.trim())
+		.slice(0, 3);
 
 	return (
 		<>
@@ -27,6 +31,7 @@ export default async function NewsletterDetailPage({ params }: { params: PagePar
 				popular={popularArticles}
 				latest={latestArticles}
 				newsId={articleContent.id}
+				related={usedNewsList}
 				prev={articleInfo.previousNewsletter}
 				next={articleInfo.nextNewsletter}
 			/>

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -272,6 +272,10 @@ const mainCardStyles = css`
 		justify-content: space-between;
 		gap: 1rem;
 
+		@media ${({ theme }) => theme.mediaQuery.tablet} {
+			flex-wrap: wrap;
+		}
+
 		.content {
 			display: flex;
 			flex-direction: column;
@@ -283,6 +287,13 @@ const mainCardStyles = css`
 				line-height: 1.5;
 				-webkit-line-clamp: 5;
 			}
+		}
+
+		.card-footer {
+			white-space: nowrap;
+			flex-wrap: wrap;
+			justify-content: flex-start;
+			align-items: center;
 		}
 
 		.image-placeholder {
@@ -341,6 +352,14 @@ const listCardStyles = css`
 			flex-direction: row;
 			gap: 1rem;
 
+			@media ${({ theme }) => theme.mediaQuery.mobile} {
+				flex-wrap: wrap;
+
+				.left {
+					min-width: 100%;
+				}
+			}
+
 			.left {
 				max-width: 70%;
 				display: flex;
@@ -351,7 +370,7 @@ const listCardStyles = css`
 
 			.image-placeholder {
 				height: fit-content;
-				max-width: 30%;
+				min-width: 30%;
 
 				@media ${({ theme }) => theme.mediaQuery.tablet} {
 					max-width: 100%;

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -5,14 +5,16 @@ import Title from './Title';
 import Text from '@/components/common/Text';
 import Imgae from '@/components/common/Image';
 import Link from 'next/link';
+import { DEFAULT_IMAGES } from '@/constants/images';
 
 interface Props {
 	className?: string;
 	type?: 'main' | 'sub' | 'list';
 	data: ICard;
+	newTab?: boolean;
 }
 
-const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data }, ref) => {
+const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data, newTab = false }, ref) => {
 	const { image, header, main, footer, url } = data;
 
 	return (
@@ -20,7 +22,7 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data 
 			<div className="card-body">
 				{type === 'main' && (
 					<>
-						<Link href={url || ''}>
+						<Link href={url || ''} target={newTab ? '_blank' : '_self'}>
 							<div className="card-header">
 								<Text size="medium" color="primary" weight="semiBold">
 									{header}
@@ -44,11 +46,9 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data 
 										</div>
 									)}
 								</div>
-								{image && (
-									<div className="image-placeholder">
-										<Imgae src={image} alt={main.title || 'card'} />
-									</div>
-								)}
+								<div className="image-placeholder">
+									<Imgae src={image || '/img/newpick_default_img.jpg'} alt={main.title || 'card'} />
+								</div>
 							</div>
 						</Link>
 					</>
@@ -62,7 +62,6 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data 
 									<Imgae src={image} alt={main.title || 'card'} />
 								</div>
 							)}
-
 							<div className="card-header">
 								{header && (
 									<Text size="small" color="primary" weight="semiBold">
@@ -91,38 +90,41 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data 
 
 				{type === 'list' && (
 					<>
-						<Link href={url || '/not-found'}>
-							<div className="card-main">
-								<div className="card-header">
-									{header && (
-										<Text size="small" color="primary" weight="semiBold">
-											{header}
-										</Text>
-									)}
-								</div>
-								<div className="content">
-									{main.title && (
-										<Text className="title" size="medium" weight="semiBold">
-											{main.title}
-										</Text>
-									)}
-									{main.description && (
-										<Text className="description" size="small">
-											{main.description}
-										</Text>
-									)}
-									{footer && (
-										<div className="card-footer" onClick={(e) => e.preventDefault()}>
-											{footer}
+						<Link href={url || '/not-found'} passHref legacyBehavior>
+							<a target={newTab ? '_blank' : '_self'} rel={newTab ? 'noopener noreferrer' : undefined}>
+								<div className="card-main">
+									<div className="card-header">
+										{header && (
+											<Text size="small" color="primary" weight="semiBold">
+												{header}
+											</Text>
+										)}
+									</div>
+									<div className="content">
+										<div className="left">
+											{main.title && (
+												<Text className="title" size="medium" weight="semiBold">
+													{main.title}
+												</Text>
+											)}
+											{main.description && (
+												<Text className="description" size="small">
+													{main.description}
+												</Text>
+											)}
+											{footer && (
+												<div className="card-footer" onClick={(e) => e.preventDefault()}>
+													{footer}
+												</div>
+											)}
 										</div>
-									)}
+
+										<div className="image-placeholder">
+											<Imgae src={image || `${DEFAULT_IMAGES.MONO}`} alt={main.title || 'card'} />
+										</div>
+									</div>
 								</div>
-							</div>
-							{image && (
-								<div className="image-placeholder">
-									<Imgae src={image} alt={main.title || 'card'} />
-								</div>
-							)}
+							</a>
 						</Link>
 					</>
 				)}
@@ -258,26 +260,34 @@ const StyledCard = styled.div<StyledProps>`
 `;
 
 const mainCardStyles = css`
-	.image-placeholder {
-		width: 40%;
-	}
-
 	.card-body {
-		gap: 1rem;
+		display: flex;
+		flex-direction: column;
+		width: 100%;
 	}
 
 	.card-main {
+		display: flex;
 		flex-direction: row;
+		justify-content: space-between;
 		gap: 1rem;
 
 		.content {
-			width: 50%;
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+
+			.description {
+				height: 100%;
+				min-height: calc(${({ theme }) => theme.fontSize.medium} * 1.5 * 5);
+				line-height: 1.5;
+				-webkit-line-clamp: 5;
+			}
 		}
 
-		.description {
-			line-height: 1.5;
-			height: calc(${({ theme }) => theme.fontSize.medium} * 1.5 * 7);
-			-webkit-line-clamp: 7;
+		.image-placeholder {
+			height: 100%;
+			min-width: 30%;
 		}
 	}
 `;
@@ -312,30 +322,41 @@ const listCardStyles = css`
 		gap: 0.5rem;
 	}
 
-	.image-placeholder {
-		height: fit-content;
-		max-width: 30%;
-		@media ${({ theme }) => theme.mediaQuery.tablet} {
-			max-width: 100%;
-		}
-	}
-
 	.card-body {
 		flex-wrap: wrap;
 		flex-direction: row;
-		padding: 1.5rem 0;
+		padding: 1.25rem 0.25rem;
 		border-bottom: 1px solid ${({ theme }) => theme.color.border};
 		gap: 1rem;
 	}
 
 	.card-main {
-		max-width: calc(70% - 1rem);
+		width: 100%;
 		flex-direction: column;
 		align-items: center;
-		gap: 0.25rem;
 
 		.content {
-			gap: 0.25rem;
+			width: 100%;
+			display: flex;
+			flex-direction: row;
+			gap: 1rem;
+
+			.left {
+				max-width: 70%;
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				gap: 0.25rem;
+			}
+
+			.image-placeholder {
+				height: fit-content;
+				max-width: 30%;
+
+				@media ${({ theme }) => theme.mediaQuery.tablet} {
+					max-width: 100%;
+				}
+			}
 		}
 
 		.description {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -53,6 +53,7 @@ export const API_ENDPOINTS = {
 		BOOKMARK: `${API_URL}/feedback/bookmark`,
 	},
 	NEWS: {
+		RELATED: (link: string) => `${API_URL}/crawling/related?link=${link}`,
 		CRAWL: () => `${API_URL}/news/crawl`,
 		GET_BY_CATEGORY: (category: string, page: number, limit: number) =>
 			`${API_URL}/news?category=${category}&page=${page}&limit=${limit}`,

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_IMAGES = {
+	MONO: '/img/newpick_default_img.jpg',
+};

--- a/src/hooks/useArticle.ts
+++ b/src/hooks/useArticle.ts
@@ -1,8 +1,10 @@
+import { NewsInfo as INewsInfo } from '@/models/article.model';
 import {
 	fetchArticle,
 	fetchArticleByCategory,
 	fetchArticleList,
 	fetchPopularArticle,
+	fetchRelatedNews,
 	fetchTrendList,
 } from '@/api/article';
 import { ArticleInfo as IArticleInfo, ArticleDetail as IArticleDetail } from '@/models/article.model';
@@ -52,4 +54,14 @@ export const getCategoryList = async (
 ): Promise<IArticleDetail[]> => {
 	const { data }: { data: IArticleDetail[] } = await fetchArticleByCategory(category, limit, offset);
 	return data;
+};
+
+export const getRelatedNews = async (links: string[]): Promise<INewsInfo[]> => {
+	const relatedNews: INewsInfo[] = await Promise.all(
+		links.map(async (link) => {
+			return await fetchRelatedNews(link);
+		})
+	);
+
+	return relatedNews;
 };

--- a/src/models/article.model.ts
+++ b/src/models/article.model.ts
@@ -27,3 +27,14 @@ export interface ArticleSummary {
 	bookmarks?: number;
 	views?: number;
 }
+
+export interface NewsInfo {
+	id: string;
+	link: string;
+	category: string[];
+	title: string;
+	content: string;
+	images: string[];
+	publishedAt: string;
+	source: string;
+}

--- a/src/models/card.model.ts
+++ b/src/models/card.model.ts
@@ -1,5 +1,5 @@
 export interface Card {
-	id: number;
+	id: number | string;
 	image?: string;
 	header: string;
 	main: {


### PR DESCRIPTION
## 작업 개요
**관련 뉴스 미리보기 기능을 추가**하고, **모바일/태블릿 환경에서 카드 컴포넌트 스타일을 개선**하였습니다.

### PR 유형  
- [x] 새로운 기능 추가  
- [x] 디자인/UI 개선  
- [x] 코드 스타일 개선  

---

### 주요 변경 사항  
- **관련 뉴스 미리보기 카드 기능 추가**  
  - 상세 페이지에서 관련 뉴스를 미리 보고 해당 뉴스로 이동할 수 있도록 기능 추가

- **모바일/태블릿 환경 스타일 개선**  
  - 카드 컴포넌트 스타일 조정 

### 기타 변경 사항

- **타이틀 및 구분자 스타일 수정**  
  - 페이지별 타이틀 구분 개선  
  - 모바일 및 태블릿 환경에서의 레이아웃 조정  

- **import문 정렬**  
  - 코드 정리를 위해 import문 순서 정리  

---

### 변경 이유  
- 상세 페이지에서 관련 뉴스를 미리 볼 수 있도록 사용자 경험 개선  
- 모바일/태블릿 환경에서 UI를 보다 일관성 있게 정리  
- 코드 가독성을 높이기 위해 import문 정렬  

---

### 테스트 결과  

![Screenshot 2025-02-05 at 01 18 32](https://github.com/user-attachments/assets/28d334b6-67b3-4d33-a57e-f331b6b3d02d)
- [x] 관련 뉴스 미리보기 기능이 정상적으로 표시되는지 확인

![Screenshot 2025-02-05 at 01 20 30](https://github.com/user-attachments/assets/782eebee-d51a-4cc3-a816-3a5e93ab9ce9)
![Screenshot 2025-02-05 at 01 20 42](https://github.com/user-attachments/assets/5701cbb3-9f2e-4690-b9b7-4715e4261284)
- [x] 모바일 및 태블릿 환경에서 카드 컴포넌트 스타일이 올바르게 적용되는지 확인
- [x] 타이틀과 구분자 스타일이 일관되게 적용되는지 확인  
- [x] import문 정렬 후 코드 정상 실행 확인