### PR TITLE
[Fix] 체험하기 모달의 관심사 선택란을 전역 상태와 분리

### DIFF
--- a/src/app/(home)/_components/Trial.tsx
+++ b/src/app/(home)/_components/Trial.tsx
@@ -5,10 +5,9 @@ import DOMPurify from 'dompurify';
 import { DEFAULT_IMAGES } from '@/constants/images';
 import { ArticleDetail as IArticleDetail } from '@/models/article.model';
 import { dateFormatter } from '@/utils/formatter';
-import { mapTitleToId } from '@/utils/mapInterests';
+import { mapIdToTitle, mapTitleToId } from '@/utils/mapInterests';
 import { parseUrls } from '@/utils/parseArticles';
 import { summarizeNews } from '@/api/ai';
-import { useSingleSelectInterest } from '@/hooks/useInterests';
 
 import styled from 'styled-components';
 import { GiNothingToSay } from 'react-icons/gi';
@@ -28,7 +27,7 @@ export default function Trial() {
 	const [newsletter, setNewsletter] = useState<IArticleDetail | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
-	const { selectedInterest = 'IT' } = useSingleSelectInterest();
+	const [selectedInterest, setSelectedInterest] = useState<string>('IT'); // 전역 상태 제거
 
 	const getStartDate = () => {
 		const now = new Date();
@@ -82,7 +81,7 @@ export default function Trial() {
 		<StyledTrial>
 			<div className="header">
 				<Text size="medium">생성하고 싶은 AI 뉴스레터의 관심사를 선택해주세요.</Text>
-				<CategoryTags select="single" />
+				<CategoryTags selectType="localSingle" onSelect={setSelectedInterest} selected={selectedInterest} />
 			</div>
 			<StyledContent>
 				{isLoading ? (
@@ -95,9 +94,15 @@ export default function Trial() {
 				) : newsletter ? (
 					<div className="content">
 						<div className="article-header">
+							{newsletter.categoryId && (
+								<Title size="extraSmall" color="primary" className="tag">
+									{mapIdToTitle([newsletter.categoryId])[0]}
+								</Title>
+							)}
 							<Title size="large" weight="semiBold" color="primary">
 								{newsletter ? newsletter.title : 'AI 뉴스레터 체험하기'}
 							</Title>
+
 							<Text size="small" color="subText" className="date">
 								{dateFormatter(newsletter.createdAt)}
 							</Text>
@@ -172,6 +177,16 @@ const StyledContent = styled.div`
 	border-radius: ${({ theme }) => theme.borderRadius.soft};
 
 	.article-header {
+		.tag {
+			width: fit-content;
+			height: fit-content;
+			padding: 0 1.5rem;
+			margin-bottom: 0.5rem;
+			background: ${({ theme }) => theme.color.tertiary};
+			color: ${({ theme }) => theme.color.primary};
+			border-radius: ${({ theme }) => theme.borderRadius.capsule};
+		}
+
 		.date {
 			width: 100%;
 			display: flex;

--- a/src/app/(home)/_components/Trial.tsx
+++ b/src/app/(home)/_components/Trial.tsx
@@ -65,8 +65,6 @@ export default function Trial() {
 				usedNews: result.newsletter.newslinks || [],
 			};
 
-			console.log('newsletter:', newsletter);
-
 			setNewsletter(newsletter);
 		} catch (error) {
 			console.error('뉴스 요약 실패:', error);

--- a/src/components/common/article/CategoryTags.tsx
+++ b/src/components/common/article/CategoryTags.tsx
@@ -3,31 +3,39 @@ import { useSelectInterests, useSingleSelectInterest } from '@/hooks/useInterest
 import { styled } from 'styled-components';
 import Button from '@/components/common/Button';
 
-type select = 'multiple' | 'single' | 'none';
+type select = 'multiple' | 'single' | 'localSingle';
 interface Props {
 	className?: string;
-	select?: select;
+	selectType?: select;
+	selected?: string;
+	onSelect?: (category: string) => void;
 }
 
-export default function CategoryTags({ className, select = 'multiple' }: Props) {
+export default function CategoryTags({ className, selectType = 'multiple', selected, onSelect }: Props) {
 	const { selectedInterest, handleSelectInterest } = useSingleSelectInterest();
 	const { selectedInterests, handleSelectInterests } = useSelectInterests();
 
 	return (
 		<StyledCategoris className={className}>
 			<ul className="categories">
-				{CATEGORIES.slice(select === 'single' ? 1 : 0).map((category, index) => (
+				{CATEGORIES.slice(selectType === 'single' || 'localSingle' ? 1 : 0).map((category, index) => (
 					<li key={index}>
 						<Button
 							type="button"
 							scheme="default"
 							onClick={
-								select === 'single'
+								selectType === 'localSingle'
+									? () => onSelect && onSelect(category.name)
+									: selectType === 'single'
 									? () => handleSelectInterest(category)
 									: () => handleSelectInterests(category)
 							}
 							className={
-								selectedInterest === category.name || selectedInterests.includes(category.name)
+								selectType === 'localSingle'
+									? selected === category.name
+										? 'category-btn active'
+										: 'category-btn'
+									: selectedInterest === category.name || selectedInterests.includes(category.name)
 									? 'category-btn active'
 									: 'category-btn'
 							}


### PR DESCRIPTION
## 작업 개요

체험하기 모달에서 관심사 선택 상태를 전역 상태에서 분리하여 독립적으로 관리할 수 있도록 수정했습니다.

### PR 유형

- [x] 코드 리팩토링
- [x] 버그 수정

---

## 주요 변경 사항

- `체험하기 모달`에서 관심사 선택 상태를 전역 상태에서 분리하여 해당 모달 내에서만 관리되도록 변경

### 기타 변경 사항

- 불필요한 디버깅 로그 제거

### 변경 이유

- 로그인 상태에서 사용자가 구독 상태인 경우 관심사가 자동으로 선택되는 문제 해결
- 관심사 선택 상태가 전역에서 관리될 필요가 없으며, 모달에서만 사용되므로 해당 로직을 분리하여 코드의 명확성을 높임