### PR TITLE
[Fix] 유저 구독 뉴스레터 날짜별 api 적용

### DIFF
--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -72,3 +72,13 @@ export const fetchRelatedNews = async (link: string) => {
 	const news = await response.json();
 	return news.data;
 };
+
+export const fetchDateNewsletter = async (limit: number = 5, offset: number = 0, startDate?: string, endDate?: string) => {
+	const response = await fetch(API_ENDPOINTS.NEWSLETTER.DATE(limit, offset, startDate, endDate));
+
+	if (!response.ok) {
+		throw new Error('날짜별 뉴스레터를 불러오는데 실패했습니다.');
+	}
+
+	return await response.json();
+};

--- a/src/app/articles/detail/[slug]/_components/LatestArticle.tsx
+++ b/src/app/articles/detail/[slug]/_components/LatestArticle.tsx
@@ -23,7 +23,7 @@ function LatestArticle({ className }: Props) {
 	return (
 		<LatestArticleStyled className={className}>
 			<div className="section-title">
-				<h3>최신 아티클</h3>
+				<h3>최신 뉴스레터</h3>
 			</div>
 			<div className="swiper-container">
 				<Swiper

--- a/src/app/articles/detail/[slug]/_components/PopularArticle.tsx
+++ b/src/app/articles/detail/[slug]/_components/PopularArticle.tsx
@@ -18,7 +18,7 @@ function PopularArticle({ flex, className }: Props) {
 
 	return (
 		<PopularNewsletterStyled flex={flex} className={className}>
-			<h3 className="section-title">지금 인기 아티클 TOP 5</h3>
+			<h3 className="section-title">지금 인기 뉴스레터 TOP 5</h3>
 			<ul className="popular-list">
 				{popularArticles && popularArticles.map((article, index) => (
 					<li key={index}>

--- a/src/components/common/icons/BookmarkIcon.tsx
+++ b/src/components/common/icons/BookmarkIcon.tsx
@@ -8,7 +8,7 @@ import { useTheme } from 'styled-components';
 import { useAddBookmarkMutation, useBookmarksList, useRemoveBookmarkMutation } from '@/hooks/useBookmark';
 
 interface BookmarkIconProps {
-	newsId: number; // 아티클 ID
+	newsId: number; // 뉴스레터 ID
 	newsletterId: number;
 	className?: string;
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -45,6 +45,8 @@ export const API_ENDPOINTS = {
 		POPULAR: (limit: number, offset: number, trend: boolean) =>
 			`${API_URL}/newsletters?limit=${limit}&offset=${offset}&trend=${trend}`,
 		SUMMARIZE: () => `${API_URL}/ai-summary/summarize`,
+		DATE: (limit: number, offset: number, startDate?: string, endDate?: string) =>
+			`${API_URL}/newsletters?limit=${limit}&offset=${offset}&startDate=${startDate}&endDate=${endDate}`,
 	},
 	FEEDBACK: {
 		BASE: () => `${API_URL}/feedback`,

--- a/src/hooks/useMySubscribe.ts
+++ b/src/hooks/useMySubscribe.ts
@@ -1,11 +1,17 @@
 import { ArticleDetail as IArticleDetail } from '@/models/article.model';
-import { fetchArticleList } from '@/api/article';
+import { fetchDateNewsletter } from '@/api/article';
+import { dateFormatter } from '@/utils/formatter';
 
 export const getTodayArticles = async (limit: number) => {
-	const data = await fetchArticleList(limit, 0);
+  const now = new Date();
+  const startDate = dateFormatter(now.toString());
+  const endDate = startDate;
+
+	const data = await fetchDateNewsletter(limit, 0, startDate, endDate);
+
+  console.log(data)
 	const newsletters: IArticleDetail[] = data.data;
 
-  const now = new Date();
 
   const threshold = new Date();
   threshold.setHours(8, 0, 0, 0);
@@ -19,7 +25,7 @@ export const getTodayArticles = async (limit: number) => {
 };
 
 export const userSubscribeArticles = async (categoryIds: number[]) => {
-  const todayNewsletter: IArticleDetail[] = await getTodayArticles(1000);
+  const todayNewsletter: IArticleDetail[] = await getTodayArticles(20);
   const userArticle = todayNewsletter.filter((n) => categoryIds.includes(n.categoryId));
 
   const latestArticlesByCategory = categoryIds


### PR DESCRIPTION
## 작업 개요

기존의 모든 리스트를 받아오는 방식에서 유저 구독한 오늘의 뉴스레터를 날짜별 api를 생성해 적용했습니다.
