### PR TITLE
[Fix/Feature] OpenGraph가 인기 뉴스레터를 가리는 문제 해결 및 뉴스 출처 표시 추가

### DIFF
--- a/src/app/articles/detail/[slug]/_components/content/ArticleContent.tsx
+++ b/src/app/articles/detail/[slug]/_components/content/ArticleContent.tsx
@@ -27,7 +27,9 @@ function ArticleContent({ content, flex, className, articleImage, related = [] }
 				<div className="content-bottom-margin" />
 			</NewsletterContentStyled>
 			<hr />
-			<OpenGraphCard urls={related} />
+			<OpenGraphCardContainer>
+				<OpenGraphCard urls={related} />
+			</OpenGraphCardContainer>
 			<SubscribeInduce className="subscribe" />
 		</ContainerStyled>
 	);
@@ -45,6 +47,20 @@ const ContainerStyled = styled.div<Omit<NewsletterContentProps, 'content'>>`
 		margin: 0;
 		border: none;
 		border-bottom: 1px solid ${({ theme }) => theme.color.border};
+	}
+`;
+
+const OpenGraphCardContainer = styled.div`
+	position: relative;
+	gap: 0.5rem;
+
+	.content-bottom-margin {
+		padding-bottom: 2rem;
+	}
+
+	* {
+		word-break: break-word;
+		line-height: 1.56;
 	}
 `;
 

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,11 +1,12 @@
-import { forwardRef } from 'react';
-import { Card as ICard } from '@/models/card.model';
-import styled, { css } from 'styled-components';
-import Title from './Title';
-import Text from '@/components/common/Text';
-import Imgae from '@/components/common/Image';
 import Link from 'next/link';
+import { forwardRef } from 'react';
 import { DEFAULT_IMAGES } from '@/constants/images';
+import { Card as ICard } from '@/models/card.model';
+
+import styled, { css } from 'styled-components';
+import Title from '@/components/common/Title';
+import Text from '@/components/common/Text';
+import Image from '@/components/common/Image';
 
 interface Props {
 	className?: string;
@@ -47,7 +48,7 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data,
 									)}
 								</div>
 								<div className="image-placeholder">
-									<Imgae src={image || '/img/newpick_default_img.jpg'} alt={main.title || 'card'} />
+									<Image src={image || '/img/newpick_default_img.jpg'} alt={main.title || 'card'} />
 								</div>
 							</div>
 						</Link>
@@ -59,7 +60,7 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data,
 						<Link href={url || '/not-found'}>
 							{image && (
 								<div className="image-placeholder">
-									<Imgae src={image} alt={main.title || 'card'} />
+									<Image src={image} alt={main.title || 'card'} />
 								</div>
 							)}
 							<div className="card-header">
@@ -120,7 +121,7 @@ const Card = forwardRef<HTMLDivElement, Props>(({ type = 'sub', className, data,
 										</div>
 
 										<div className="image-placeholder">
-											<Imgae src={image || `${DEFAULT_IMAGES.MONO}`} alt={main.title || 'card'} />
+											<Image src={image || `${DEFAULT_IMAGES.MONO}`} alt={main.title || 'card'} />
 										</div>
 									</div>
 								</div>

--- a/src/components/common/article/OpenGraphCard.tsx
+++ b/src/components/common/article/OpenGraphCard.tsx
@@ -46,7 +46,16 @@ export default function OpenGraphCard({ urls }: Props) {
 							id: news.id,
 							url: news.link,
 							image: news.images[0],
-							header: news.category[0],
+							header: (
+								<div className="news-header">
+									<Text size="medium" weight="semiBold" color="primary">
+										{news.category[0]}
+									</Text>
+									<Text size="medium" color="subText" className="source">
+										{news.source}
+									</Text>
+								</div>
+							),
 							main: {
 								title: news.title,
 								description: news.content,
@@ -91,8 +100,25 @@ const StyledOpenGraphCard = styled.div`
 		padding: 1rem;
 		gap: 0;
 
-		.card-header {
-			display: none;
+		.news-header {
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			align-items: center;
+			gap: 0.25rem;
+
+			.source {
+				padding: 0.1rem 1rem;
+				border-radius: ${({ theme }) => theme.borderRadius.capsule};
+				border: 1px solid ${({ theme }) => theme.color.border};
+			}
+
+			.bar {
+				width: 1px;
+				height: ${({ theme }) => theme.fontSize.medium};
+				border-left: 1px solid ${({ theme }) => theme.color.subText};
+				margin: 0 0.5rem;
+			}
 		}
 
 		.card-body {

--- a/src/models/card.model.ts
+++ b/src/models/card.model.ts
@@ -1,7 +1,7 @@
 export interface Card {
 	id: number | string;
 	image?: string;
-	header: string;
+	header: string | React.ReactNode;
 	main: {
 		title?: string;
 		description: string;


### PR DESCRIPTION
## 작업 개요

- 이미지가 없는 경우 OpenGraph가 인기 뉴스레터를 가리는 문제를 해결  
- 뉴스 카드 및 뉴스 요약 섹션에 출처 표시를 추가하여 사용자에게 정보 제공 강화  

### PR 유형  
- [x] 새로운 기능 추가  
- [x] UI 개선  

---  

## 주요 변경 사항  
- 이미지가 없는 경우 기본 플레이스홀더를 적용하여 OpenGraph가 인기 뉴스레터를 가리지 않도록 수정  
- 뉴스 카드 및 뉴스 요약에 출처 정보를 추가

### 변경 이유  
- 이미지가 없는 경우 레이아웃이 깨지거나 OpenGraph 영역이 인기 뉴스레터 콘텐츠를 가리는 문제가 발생  
- 사용자가 뉴스를 신뢰할 수 있도록 출처 정보를 명확하게 제공할 필요가 있음  

---  

## 테스트 결과  

![Screenshot 2025-02-06 at 00 37 49](https://github.com/user-attachments/assets/1c5db299-5661-4d1a-8206-66c5a4e60046)

- 이미지가 없는 뉴스에서도 레이아웃이 정상적으로 유지됨을 확인  
- 뉴스 카드에 출처가 정상적으로 표시됨을 확인  