### PR TITLE
[Fix] 뉴스레터 체험하기에서 날짜 설정 어제로 고정

### DIFF
--- a/src/app/(home)/_components/Trial.tsx
+++ b/src/app/(home)/_components/Trial.tsx
@@ -31,10 +31,8 @@ export default function Trial() {
 
 	const getStartDate = () => {
 		const now = new Date();
-		const hours = now.getHours();
-		// 현재 시간이 오전 8시 이전이면 어제 날짜, 이후면 오늘 날짜 사용
-		const targetDate = hours < 9 ? new Date(now.setDate(now.getDate() - 1)) : now;
-		return dateFormatter(targetDate.toISOString().split('T')[0]);
+		now.setDate(now.getDate() - 1);
+		return dateFormatter(now.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }));
 	};
 
 	const handleGenerateNewsletter = async () => {

--- a/src/components/common/article/SubscribeInduce.tsx
+++ b/src/components/common/article/SubscribeInduce.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTab } from '@/hooks/useTab';
 import { useModal } from '@/hooks/useModal';
 
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import Button from '@/components/common/Button';
 import ModalContent from '@/components/common/modal/ModalContent';
 import { BiSolidMessageRoundedError } from 'react-icons/bi';
@@ -22,6 +22,8 @@ function SubscribeInduce({ className }: Props) {
 	const { setActiveTab } = useTab();
 	const [isSubscribeClicked, setIsSubscribeClicked] = useState(false);
 	const { openModal, closeModal } = useModal();
+
+	const { themeName } = useTheme();
 
 	useEffect(() => {
 		if (isSubscribeClicked && user) {
@@ -63,7 +65,7 @@ function SubscribeInduce({ className }: Props) {
 	};
 
 	return (
-		<SubscribeInduceStyled className={className}>
+		<SubscribeInduceStyled className={className} $themeName={themeName}>
 			<p>뉴픽이 보내드리는 뉴스레터를 구독해보세요!</p>
 			<Button scheme="primary" size="medium" onClick={onClickSubscribe}>
 				구독하기
@@ -72,7 +74,11 @@ function SubscribeInduce({ className }: Props) {
 	);
 }
 
-const SubscribeInduceStyled = styled.div`
+interface StyledProps {
+	$themeName: 'light' | 'dark';
+}
+
+const SubscribeInduceStyled = styled.div<StyledProps>`
 	background-color: ${({ theme }) => theme.color.tertiary};
 	border-radius: ${({ theme }) => theme.borderRadius.soft};
 	padding: 2rem 4rem;
@@ -86,7 +92,10 @@ const SubscribeInduceStyled = styled.div`
 		width: 100%;
 		font-size: ${({ theme }) => theme.fontSize.extraLarge};
 		font-weight: ${({ theme }) => theme.fontWeight.semiBold};
-		background: linear-gradient(to right top, #0c0042, #2d11b1, #5537dd, #0e004d);
+		background: ${({ $themeName }) =>
+			$themeName === 'light'
+				? 'linear-gradient(to right top, #0c0042, #2d11b1, #5537dd, #0e004d)'
+				: 'linear-gradient(to right top, #3b1d91, #5b40e0, #7761ff, #a28eff)'};
 		color: transparent;
 		-webkit-background-clip: text;
 

--- a/src/hooks/useMySubscribe.ts
+++ b/src/hooks/useMySubscribe.ts
@@ -17,7 +17,6 @@ export const getTodayArticles = async (limit: number) => {
 	const formattedEndDate = formattedStartDate;
 
 	const data = await fetchDateNewsletter(limit, 0, formattedStartDate, formattedEndDate);
-	console.log(data);
 	const newsletters: IArticleDetail[] = data.data;
 
 	const TodayNewsletter = newsletters.filter((n) => new Date(n.createdAt) >= threshold);


### PR DESCRIPTION
## 작업 개요  

뉴스레터 생성 시도 시 날짜를 **무조건 어제 날짜로 설정**하도록 수정했습니다.  

### PR 유형  
- [x] 버그 수정  
- [ ] 새로운 기능 추가  
- [ ] 코드 리팩토링  
- [ ] 문서 수정  
- [ ] 기타  

## 주요 변경 사항  
- **날짜 설정 로직 수정**: 기존에는 현재 날짜+오전 8시를 기준으로 설정되었으나, 이를 **어제 날짜로 고정**하도록 변경했습니다.  

### 기타 변경 사항
- **디버깅 로그 제거**: 필요 없는 디버깅 로그를 삭제하여 코드 정리 진행.  
- **구독 유도 컴포넌트에서 다크 모드 그래디언트 색상 변경**: UI 개선을 위해 다크 모드일 때의 그라디언트 색상을 변경했습니다.  

### 테스트 결과
[x] 뉴스레터 생성 시 정상적으로 어제 날짜로 요청됨을 확인했습니다.  
[x] 다크 모드에서 변경된 그래디언트가 정상적으로 적용됨을 확인했습니다.  